### PR TITLE
Extend expression support

### DIFF
--- a/coffee/autotuner.py
+++ b/coffee/autotuner.py
@@ -281,7 +281,7 @@ int main()
                     return loop_sizes[node.rank[0]] if node.rank[0] != '0' else 1
                 return 0
             elif isinstance(node, For):
-                loop_sizes[node.itvar] = node.size
+                loop_sizes[node.dim] = node.size
             for n in node.children:
                 size = find_coeff_size(n, coeff, loop_sizes)
                 if size:

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -937,9 +937,9 @@ def c_sym(const):
 
 
 def c_for(var, to, code, pragma="#pragma coffee itspace", init=None):
-    i = c_sym(var)
-    init = init or c_sym(0)
-    end = c_sym(to)
+    i = Symbol(var)
+    init = init or Symbol(0)
+    end = Symbol(to)
     if type(code) == str:
         code = FlatBlock(code)
     elif type(code) == list:
@@ -947,7 +947,7 @@ def c_for(var, to, code, pragma="#pragma coffee itspace", init=None):
     elif type(code) is not Block:
         code = Block([code], open_scope=True)
     return Block(
-        [For(Decl("int", i, init), Less(i, end), Incr(i, c_sym(1)),
+        [For(Decl("int", i, init), Less(i, end), Incr(i, Symbol(1)),
              code, pragma)], open_scope=True)
 
 

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -34,7 +34,12 @@
 """This file contains the hierarchy of classes that implement a kernel's
 Abstract Syntax Tree (AST)."""
 
-
+try:
+    from collections import OrderedDict
+# OrderedDict was added in Python 2.7. Earlier versions can use ordereddict
+# from PyPI
+except ImportError:
+    from ordereddict import OrderedDict
 from copy import deepcopy as dcopy
 
 # Utilities for simple exprs and commands
@@ -667,6 +672,11 @@ class For(Statement):
     @body.setter
     def body(self, new_body):
         self.children[0].children = new_body
+
+    @staticmethod
+    def fromloops(loops):
+        loops_dims = [l.dim for l in loops]
+        return OrderedDict(zip(loops_dims, loops))
 
     def gencode(self, not_scope=False):
         return "\n".join(self.pragma) + "\n" + for_loop(self.init.gencode(True),

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -638,7 +638,7 @@ class For(Statement):
         self.incr = incr
 
     @property
-    def itvar(self):
+    def dim(self):
         if isinstance(self.init, Decl):
             return self.init.sym.symbol
         elif isinstance(self.init, Assign):

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -565,8 +565,18 @@ class Decl(Statement, Perfect):
 
     @property
     def is_const(self):
-        """Return True if the declaration is a constant."""
+        """Return True if the declared symbol is constant"""
         return 'const' in self.qual
+
+    @property
+    def is_static(self):
+        """Return True if the declared symbol is static"""
+        return 'static' in self.qual
+
+    @property
+    def is_static_const(self):
+        """Return True if the declared symbol is static and constant"""
+        return self.is_static and self.is_const
 
     @property
     def scope(self):
@@ -580,15 +590,8 @@ class Decl(Statement, Perfect):
             raise RuntimeError("Only %s are valid scopes" % Scope._scopes)
         self._scope = val
 
-    def gencode(self, not_scope=False):
-        if isinstance(self.init, EmptyStatement):
-            return decl(spacer(self.qual), self.typ, self.sym.gencode(),
-                        spacer(self.attr)) + semicolon(not_scope)
-        else:
-            return decl_init(spacer(self.qual), self.typ, self.sym.gencode(),
-                             spacer(self.attr), self.init.gencode()) + semicolon(not_scope)
-
-    def get_nonzero_columns(self):
+    @property
+    def nonzero(self):
         """If the declared array:
 
         * is a bi-dimensional array,
@@ -601,6 +604,14 @@ class Decl(Statement, Perfect):
             return self.init.nonzero_bounds
         else:
             return ()
+
+    def gencode(self, not_scope=False):
+        if isinstance(self.init, EmptyStatement):
+            return decl(spacer(self.qual), self.typ, self.sym.gencode(),
+                        spacer(self.attr)) + semicolon(not_scope)
+        else:
+            return decl_init(spacer(self.qual), self.typ, self.sym.gencode(),
+                             spacer(self.attr), self.init.gencode()) + semicolon(not_scope)
 
 
 class Block(Statement):

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -153,6 +153,14 @@ class BinExpr(Expr):
     def gencode(self, not_scope=True):
         return (" "+self.op+" ").join([n.gencode(not_scope) for n in self.children])
 
+    @property
+    def left(self):
+        return self.children[0]
+
+    @property
+    def right(self):
+        return self.children[1]
+
 
 class UnaryExpr(Expr):
 
@@ -167,6 +175,10 @@ class UnaryExpr(Expr):
         dictionary tracking the objects copied up to ``self``, which is used
         by the classic ``deepcopy`` method, is ignored."""
         return self.__class__(dcopy(self.children[0]))
+
+    @property
+    def child(self):
+        return self.children[0]
 
 
 class Neg(UnaryExpr):

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -601,8 +601,6 @@ class Decl(Statement, Perfect):
 
     @scope.setter
     def scope(self, val):
-        if val not in Scope._scopes:
-            raise RuntimeError("Only %s are valid scopes" % Scope._scopes)
         self._scope = val
 
     @property
@@ -999,11 +997,12 @@ def c_flat_for(code, parent):
 
 class Access(object):
 
-    def __init__(self, mode):
-        self._mode = mode
+    _modes = ["READ", "WRITE", "RW", "INC", "DEC", "IMUL", "IDIV"]
 
-    def __eq__(self, other):
-        return self._mode == other._mode
+    def __init__(self, mode):
+        if mode not in Access._modes:
+            raise TypeError
+        self._mode = mode
 
 
 READ = Access("READ")
@@ -1013,7 +1012,6 @@ INC = Access("INC")
 DEC = Access("DEC")
 IMUL = Access("IMUL")
 IDIV = Access("IDIV")
-Access._modes = [READ, WRITE, RW, INC, DEC, IMUL, IDIV]
 
 
 # Scope of a declaration ##
@@ -1024,15 +1022,15 @@ class Scope(object):
     when it appears in the list of declarations of a /FunDecl/ object). Otherwise,
     a ``LOCAL`` scope indicates the /Decl/ is within the body of a kernel."""
 
-    def __init__(self, scope):
-        self._scope = scope
+    _scopes = ["LOCAL", "EXTERNAL"]
 
-    def __eq__(self, other):
-        return self._scope == other._scope
+    def __init__(self, scope):
+        if scope not in Scope._scopes:
+            raise TypeError
+        self._scope = scope
 
     def __str__(self):
         return self._scope
 
 LOCAL = Scope("LOCAL")
 EXTERNAL = Scope("EXTERNAL")
-Scope._scopes = [LOCAL, EXTERNAL]

--- a/coffee/expression.py
+++ b/coffee/expression.py
@@ -96,6 +96,10 @@ class MetaExpr(object):
         return tuple(set(self.loops_info) - set(self.domain_loops_info))
 
     @property
+    def out_loop(self):
+        return self.loops[0]
+
+    @property
     def perfect_loops(self):
         """Return the loops in a perfect loop nest for the expression."""
         return [l for l in self.loops if is_perfect_loop(l)]

--- a/coffee/expression.py
+++ b/coffee/expression.py
@@ -38,20 +38,22 @@ class MetaExpr(object):
 
     """Metadata container for a compute-intensive expression."""
 
-    def __init__(self, type, parent, loops_info, unit_stride_itvars):
+    def __init__(self, type, parent, loops_info, domain):
         """Initialize the MetaExpr.
 
         :param type: the C type of the expression.
         :param parent: the parent block node in which the expression is embedded.
-        :param loops_info: the ordered tuple of (loop, parent) the expression
-                           depends on.
-        :param unit_stride_itvars: the unite-stride loop dimensions, as iteration
-                                   variables, along which writes are performed.
+        :param loops_info: the ordered tuple of (loop, parent) the expression is
+                           enclosed in.
+        :param domain: an ``n``-tuple, where ``n`` is the rank of the tensor
+                       evaluated by the expression. The i-th entry corresponds to
+                       the loop dimension along which iteration occurs (For example,
+                       given an output tensor ``A[i][j]``, ``domain=(i, j)``).
         """
         self._type = type
         self._parent = parent
         self._loops_info = loops_info
-        self._unit_stride_itvars = unit_stride_itvars
+        self._domain = domain
 
     @property
     def type(self):
@@ -70,30 +72,28 @@ class MetaExpr(object):
         return self._loops_info
 
     @property
-    def unit_stride_loops(self):
-        return tuple([l for l in self.loops if l.itvar in self._unit_stride_itvars])
+    def domain_loops(self):
+        return tuple([l for l in self.loops if l.itvar in self._domain])
 
     @property
-    def unit_stride_loops_parents(self):
-        return tuple([p for l, p in self._loops_info if l.itvar
-                      in self._unit_stride_itvars])
+    def domain_loops_parents(self):
+        return tuple([p for l, p in self._loops_info if l.itvar in self._domain])
 
     @property
-    def unit_stride_loops_info(self):
-        return tuple([(l, p) for l, p in self._loops_info if l.itvar
-                      in self._unit_stride_itvars])
+    def domain_loops_info(self):
+        return tuple([(l, p) for l, p in self._loops_info if l.itvar in self._domain])
 
     @property
-    def slow_loops(self):
-        return tuple(set(self.loops) - set(self.unit_stride_loops))
+    def out_domain_loops(self):
+        return tuple(set(self.loops) - set(self.domain_loops))
 
     @property
-    def slow_loops_parents(self):
-        return tuple(set(self.loops_parents) - set(self.unit_stride_loops_parents))
+    def out_domain_loops_parents(self):
+        return tuple(set(self.loops_parents) - set(self.domain_loops_parents))
 
     @property
-    def slow_loops_info(self):
-        return tuple(set(self.loops_info) - set(self.unit_stride_loops_info))
+    def out_domain_loops_info(self):
+        return tuple(set(self.loops_info) - set(self.domain_loops_info))
 
     @property
     def perfect_loops(self):
@@ -105,12 +105,12 @@ class MetaExpr(object):
         return self._parent
 
     @property
-    def unit_stride_itvars(self):
-        return self._unit_stride_itvars
+    def domain(self):
+        return self._domain
 
     @property
     def dimension(self):
-        return len(self.unit_stride_loops)
+        return len(self._domain)
 
 
 def copy_metaexpr(expr_info, **kwargs):
@@ -121,12 +121,10 @@ def copy_metaexpr(expr_info, **kwargs):
     * ``parent``: the block node that embeds the expression.
     * ``loops_info``: an iterator of 2-tuple ``(loop, loop_parent)`` which
       substitute analogous information in the new ``MetaExpr``.
-    * ``itvars``: the iteration variables along which the expression performs
-      unit-stride accesses.
+    * ``domain``: the domain of the output tensor evaluated by the expression.
     """
-
     parent = kwargs.get('parent', expr_info.parent)
-    unit_stride_itvars = kwargs.get('itvars', expr_info.unit_stride_itvars)
+    domain = kwargs.get('domain', expr_info.domain)
 
     new_loops_info, old_loops_info = [], expr_info.loops_info
     to_replace_loops_info = kwargs.get('loops_info', [])
@@ -139,4 +137,4 @@ def copy_metaexpr(expr_info, **kwargs):
         else:
             new_loops_info.append(loop_info)
 
-    return MetaExpr(expr_info.type, parent, new_loops_info, unit_stride_itvars)
+    return MetaExpr(expr_info.type, parent, new_loops_info, domain)

--- a/coffee/expression.py
+++ b/coffee/expression.py
@@ -114,7 +114,15 @@ class MetaExpr(object):
 
     @property
     def dimension(self):
-        return len(self._domain)
+        return len(self._domain) if not self.is_scalar else 0
+
+    @property
+    def is_scalar(self):
+        return all([isinstance(i, int) for i in self.domain])
+
+    @property
+    def is_tensor(self):
+        return not self.is_scalar
 
 
 def copy_metaexpr(expr_info, **kwargs):

--- a/coffee/expression.py
+++ b/coffee/expression.py
@@ -108,6 +108,10 @@ class MetaExpr(object):
     def unit_stride_itvars(self):
         return self._unit_stride_itvars
 
+    @property
+    def dimension(self):
+        return len(self.unit_stride_loops)
+
 
 def copy_metaexpr(expr_info, **kwargs):
     """Given a ``MetaExpr``, return a plain new ``MetaExpr`` starting from a

--- a/coffee/expression.py
+++ b/coffee/expression.py
@@ -73,15 +73,15 @@ class MetaExpr(object):
 
     @property
     def domain_loops(self):
-        return tuple([l for l in self.loops if l.itvar in self._domain])
+        return tuple([l for l in self.loops if l.dim in self._domain])
 
     @property
     def domain_loops_parents(self):
-        return tuple([p for l, p in self._loops_info if l.itvar in self._domain])
+        return tuple([p for l, p in self._loops_info if l.dim in self._domain])
 
     @property
     def domain_loops_info(self):
-        return tuple([(l, p) for l, p in self._loops_info if l.itvar in self._domain])
+        return tuple([(l, p) for l, p in self._loops_info if l.dim in self._domain])
 
     @property
     def out_domain_loops(self):
@@ -128,12 +128,12 @@ def copy_metaexpr(expr_info, **kwargs):
 
     new_loops_info, old_loops_info = [], expr_info.loops_info
     to_replace_loops_info = kwargs.get('loops_info', [])
-    to_replace_loops_info = dict(zip([l.itvar for l, p in to_replace_loops_info],
+    to_replace_loops_info = dict(zip([l.dim for l, p in to_replace_loops_info],
                                      to_replace_loops_info))
     for loop_info in old_loops_info:
-        loop_itvar = loop_info[0].itvar
-        if loop_itvar in to_replace_loops_info:
-            new_loops_info.append(to_replace_loops_info[loop_itvar])
+        loop_dim = loop_info[0].dim
+        if loop_dim in to_replace_loops_info:
+            new_loops_info.append(to_replace_loops_info[loop_dim])
         else:
             new_loops_info.append(loop_info)
 

--- a/coffee/linear_algebra.py
+++ b/coffee/linear_algebra.py
@@ -150,11 +150,9 @@ class LinearAlgebra(object):
                 new_outer = dcopy(self.outer_loop)
                 new_outer.body = [middle_loop]
                 self.header.children.insert(ofs, new_outer)
-                loop_itvars = (self.outer_loop.itvar, middle_loop.itvar,
-                               inner_loop[0].itvar)
-                loop_sizes = (self.outer_loop.size, middle_loop.size,
-                              inner_loop[0].size)
-                loop_info = OrderedDict(zip(loop_itvars, loop_sizes))
+                loop_dims = (self.outer_loop.dim, middle_loop.dim, inner_loop[0].dim)
+                loop_sizes = (self.outer_loop.size, middle_loop.size, inner_loop[0].size)
+                loop_info = OrderedDict(zip(loop_dims, loop_sizes))
                 to_transform[new_outer] = (body[0].children[0], rhs, loop_info)
                 found_mmm = True
         # Clean up

--- a/coffee/linear_algebra.py
+++ b/coffee/linear_algebra.py
@@ -104,11 +104,10 @@ class LinearAlgebra(object):
             - Sum -> ()
             - Prod(Sum, s1) -> ()"""
             if isinstance(node, Par):
-                return check_prod(node.children[0])
+                return check_prod(node.child)
             elif isinstance(node, Prod):
-                left, right = (node.children[0], node.children[1])
-                if isinstance(left, Expr) and isinstance(right, Expr):
-                    return (left, right)
+                if isinstance(node.left, Expr) and isinstance(node.right, Expr):
+                    return (node.left, node.right)
                 return ()
             return ()
 

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -516,7 +516,7 @@ class ZeroLoopScheduler(LoopScheduler):
 
         If there are no zero-columns, return {}."""
         if isinstance(node, Symbol):
-            if node.offset:
+            if any([o != (1, 0) for o in node.offset]):
                 raise RuntimeError("Zeros error: offsets not supported: %s" % str(node))
             nz_bounds = self.nonzero_syms.get(node.symbol)
             if nz_bounds:

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -666,7 +666,7 @@ class ZeroLoopScheduler(LoopScheduler):
         """
 
         new_exprs = {}
-        _nonzero_info = {}
+        nonzero_info = {}
         track_exprs = {}
         for loop, stmt_itspaces in self.nonzero_info.items():
             fissioned_loops = defaultdict(list)
@@ -700,13 +700,13 @@ class ZeroLoopScheduler(LoopScheduler):
                                                         loops_info=loops_info)
                     self.hoisted.update_stmt(stmt.children[0].symbol,
                                              loop=loops_info[0][0], place=root)
-                _nonzero_info[loops_info[-1][0]] = stmt_ofs
+                nonzero_info[loops_info[-1][0]] = stmt_ofs
                 # Append the created loops to the root
                 index = root.children.index(loop[0])
                 root.children.insert(index, loops_info[0][0])
             root.children.remove(loop[0])
 
-        self.nonzero_info = _nonzero_info
+        self.nonzero_info = nonzero_info
         return new_exprs
 
     def reschedule(self):

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -269,15 +269,12 @@ class ExpressionFissioner(LoopScheduler):
         if isinstance(node, Symbol):
             return False
         elif isinstance(node, Par):
-            return self._split_sum(node.children[0], (node, 0), is_left, found,
-                                   sum_count)
+            return self._split_sum(node.child, (node, 0), is_left, found, sum_count)
         elif isinstance(node, Prod) and found:
             return False
         elif isinstance(node, Prod) and not found:
-            if not self._split_sum(node.children[0], (node, 0), is_left, found,
-                                   sum_count):
-                return self._split_sum(node.children[1], (node, 1), is_left, found,
-                                       sum_count)
+            if not self._split_sum(node.left, (node, 0), is_left, found, sum_count):
+                return self._split_sum(node.right, (node, 1), is_left, found, sum_count)
             return True
         elif isinstance(node, Sum):
             sum_count += 1
@@ -288,16 +285,14 @@ class ExpressionFissioner(LoopScheduler):
                 # Perform the cut
                 if is_left:
                     parent, parent_leaf = parent
-                    parent.children[parent_leaf] = node.children[0]
+                    parent.children[parent_leaf] = node.left
                 else:
                     found, found_leaf = found
-                    found.children[found_leaf] = node.children[1]
+                    found.children[found_leaf] = node.right
                 return True
             else:
-                if not self._split_sum(node.children[0], (node, 0), is_left,
-                                       found, sum_count):
-                    return self._split_sum(node.children[1], (node, 1), is_left,
-                                           found, sum_count)
+                if not self._split_sum(node.left, (node, 0), is_left, found, sum_count):
+                    return self._split_sum(node.right, (node, 1), is_left, found, sum_count)
                 return True
         else:
             raise RuntimeError("Split error: found unknown node: %s" % str(node))
@@ -430,7 +425,7 @@ class ZeroLoopScheduler(LoopScheduler):
         if isinstance(node, Symbol):
             return (node.rank[-1], self.nonzero_syms[node.symbol])
         elif isinstance(node, Par):
-            return self._get_nz_bounds(node.children[0])
+            return self._get_nz_bounds(node.child)
         elif isinstance(node, Prod):
             return tuple([self._get_nz_bounds(n) for n in node.children])
         else:

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -620,7 +620,7 @@ class ZeroLoopScheduler(LoopScheduler):
         # Initialize a dict mapping symbols to their zero columns with the info
         # already available in the kernel's declarations
         for s, d in self.decls.items():
-            nz_col_bounds = d.get_nonzero_columns()
+            nz_col_bounds = d.nonzero
             if nz_col_bounds:
                 # Note that nz_bounds are stored as second element of a 2-tuple,
                 # because the declared array is two-dimensional, in which the

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -423,7 +423,7 @@ class ZeroLoopScheduler(LoopScheduler):
         """
         self.exprs = exprs
         self.expr_graph = expr_graph
-        self.kernel_decls, self.hoisted = decls
+        self.decls, self.hoisted = decls
         # Track zero blocks in each symbol accessed in the computation rooted in root
         self.nz_in_syms = {}
         # Track blocks accessed for evaluating symbols in the various for loops
@@ -624,16 +624,15 @@ class ZeroLoopScheduler(LoopScheduler):
 
         # Initialize a dict mapping symbols to their zero columns with the info
         # already available in the kernel's declarations
-        for i, j in self.kernel_decls.items():
-            nz_col_bounds = j[0].get_nonzero_columns()
+        for s, d in self.decls.items():
+            nz_col_bounds = d.get_nonzero_columns()
             if nz_col_bounds:
                 # Note that nz_bounds are stored as second element of a 2-tuple,
                 # because the declared array is two-dimensional, in which the
                 # second dimension represents the columns
-                self.nz_in_syms[i] = (((0, j[0].sym.rank[0] - 1),),
-                                      (nz_col_bounds,))
+                self.nz_in_syms[s] = (((0, d.sym.rank[0]-1),), (nz_col_bounds,))
             else:
-                self.nz_in_syms[i] = tuple(((0, r-1),) for r in j[0].size)
+                self.nz_in_syms[s] = tuple(((0, r-1),) for r in d.size)
 
         # If zeros were not found, then just give up
         if not self.nz_in_syms:

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -411,19 +411,19 @@ class ZeroLoopScheduler(LoopScheduler):
           B[i] = E[i]*F[i]
     """
 
-    def __init__(self, exprs, expr_graph, decls):
+    def __init__(self, exprs, expr_graph, decls, hoisted):
         """Initialize the ZeroLoopScheduler.
 
         :param exprs: the expressions for which the zero-elimination is performed.
         :param expr_graph: the ExpressionGraph tracking all data dependencies involving
                            identifiers that appear in ``root``.
-        :param decls: lists of array declarations. A 2-tuple is expected: the first
-                      element is the list of kernel declarations; the second element
-                      is the list of hoisted temporaries declarations.
+        :param decls: lists of declarations visible to ``exprs``.
+        :param hoisted: dictionary that tracks hoisted sub-expressions
         """
         self.exprs = exprs
         self.expr_graph = expr_graph
-        self.decls, self.hoisted = decls
+        self.decls = decls
+        self.hoisted = hoisted
         # Track zero blocks in each symbol accessed in the computation rooted in root
         self.nz_in_syms = {}
         # Track blocks accessed for evaluating symbols in the various for loops

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -710,7 +710,7 @@ class ZeroLoopScheduler(LoopScheduler):
         roots, new_exprs = set(), {}
         elf = ExpressionFissioner(1)
         for stmt, expr_info in self.exprs.items():
-            if expr_info.dimension == 0:
+            if expr_info.is_scalar:
                 continue
             elif expr_info.dimension > 1:
                 # Split expressions based on sum's associativity. This exposes more

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -696,10 +696,10 @@ class ZeroLoopScheduler(LoopScheduler):
                     # Update expressions and hoisting-related information
                     if stmt in track_exprs:
                         new_exprs[stmt] = copy_metaexpr(track_exprs[stmt],
-                                                        **{'parent': inner_block,
-                                                           'loops_info': loops_info})
+                                                        parent=inner_block,
+                                                        loops_info=loops_info)
                     self.hoisted.update_stmt(stmt.children[0].symbol,
-                                             **{'loop': loops_info[0][0], 'place': root})
+                                             loop=loops_info[0][0], place=root)
                 _nonzero_info[loops_info[-1][0]] = stmt_ofs
                 # Append the created loops to the root
                 index = root.children.index(loop[0])

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -732,8 +732,8 @@ class ZeroLoopScheduler(LoopScheduler):
             # columns in different positions
             if expr_info.unit_stride_loops:
                 new_exprs.update(elf.fission(expr, False))
-	        roots.add(expr_info.unit_stride_loops_parents[0])
-		self.exprs.pop(stmt)
+                roots.add(expr_info.unit_stride_loops_parents[0])
+                self.exprs.pop(stmt)
             elif expr_info.slow_loops:
                 roots.add(expr_info.slow_loops_parents[0])
             else:

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -88,7 +88,7 @@ class LoopOptimizer(object):
                                     self.hoisted, self.expr_graph)
             if level > 0:
                 ew.licm()
-            if level > 1 and expr_info.dimension:
+            if level > 1 and expr_info.is_tensor:
                 ew.expand()
                 ew.factorize()
                 ew.licm(merge_and_simplify=True, compact_tmps=True)

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -95,7 +95,7 @@ class LoopOptimizer(object):
             if level > 0:
                 ew.licm()
             if level > 1:
-                if not expr_info.unit_stride_loops:
+                if not expr_info.domain_loops:
                     continue
                 ew.expand()
                 ew.distribute()
@@ -202,7 +202,7 @@ class LoopOptimizer(object):
                     do_not_precompute.add(l.loop)
         to_remove, precomputed_block, precomputed_syms = ([], [], {})
         for i in self.loop.body:
-            if i in flatten(self.expr_unit_stride_loops):
+            if i in flatten(self.expr_domain_loops):
                 break
             elif i not in do_not_precompute:
                 precompute_stmt(i, precomputed_syms, precomputed_block)
@@ -238,14 +238,14 @@ class LoopOptimizer(object):
     @property
     def expr_loops(self):
         """Return ``[(loop1, loop2, ...), ...]``, where each tuple contains all
-        loops that expressions depend on."""
+        loops enclosing expressions."""
         return [expr_info.loops for expr_info in self.exprs.values()]
 
     @property
-    def expr_unit_stride_loops(self):
+    def expr_domain_loops(self):
         """Return ``[(loop1, loop2, ...), ...]``, where a tuple contains all
-        loops along which an expression performs unit-stride memory accesses."""
-        return [expr_info.unit_stride_loops for expr_info in self.exprs.values()]
+        loops representing the domain of the expressions' output tensor."""
+        return [expr_info.domain_loops for expr_info in self.exprs.values()]
 
 
 class CPULoopOptimizer(LoopOptimizer):

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -98,7 +98,7 @@ class LoopOptimizer(object):
                 if not expr_info.domain_loops:
                     continue
                 ew.expand()
-                ew.distribute()
+                ew.factorize()
                 ew.licm(merge_and_simplify=True, compact_tmps=True)
 
     def eliminate_zeros(self):

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -111,8 +111,7 @@ class LoopOptimizer(object):
         # the iteration spaces of the enclosing loops accordingly.
         if not any([d.get_nonzero_columns() for d in self.decls.values()]):
             return
-
-        zls = ZeroLoopScheduler(self.exprs, self.expr_graph, (self.decls, self.hoisted))
+        zls = ZeroLoopScheduler(self.exprs, self.expr_graph, self.decls, self.hoisted)
         zls.reschedule()
         self.nonzero_info = zls.nonzero_info
 

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -99,7 +99,7 @@ class LoopOptimizer(object):
         # Search for zero-valued columns and restructure the iteration spaces;
         # the ZeroLoopScheduler analyzes statements "one by one", and changes
         # the iteration spaces of the enclosing loops accordingly.
-        if not any([d.get_nonzero_columns() for d in self.decls.values()]):
+        if not any([d.nonzero for d in self.decls.values()]):
             return
         zls = ZeroLoopScheduler(self.exprs, self.expr_graph, self.decls, self.hoisted)
         zls.reschedule()

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -204,16 +204,16 @@ class LoopOptimizer(object):
         searching_stmt = []
         for i in precomputed_block:
             if searching_stmt and not isinstance(i, (Assign, Incr)):
-                new_outer_block.append(ast_c_for(searching_stmt, self.loop))
+                new_outer_block.append(ast_make_for(searching_stmt, self.loop))
                 searching_stmt = []
             if isinstance(i, For):
-                new_outer_block.append(ast_c_for([i], self.loop))
+                new_outer_block.append(ast_make_for([i], self.loop))
             elif isinstance(i, (Assign, Incr)):
                 searching_stmt.append(i)
             else:
                 new_outer_block.append(i)
         if searching_stmt:
-            new_outer_block.append(ast_c_for(searching_stmt, self.loop))
+            new_outer_block.append(ast_make_for(searching_stmt, self.loop))
 
         # Update the AST adding the newly precomputed blocks
         insert_at_elem(self.header.children, self.loop, new_outer_block)

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -216,9 +216,7 @@ class LoopOptimizer(object):
             new_outer_block.append(ast_c_for(searching_stmt, self.loop))
 
         # Update the AST adding the newly precomputed blocks
-        root = self.header.children
-        ofs = root.index(self.loop)
-        self.header.children = root[:ofs] + new_outer_block + root[ofs:]
+        insert_at_elem(self.header.children, self.loop, new_outer_block)
 
         # Update the AST by scalar-expanding the pre-computed accessed variables
         ast_update_rank(self.loop, precomputed_syms)

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -325,8 +325,8 @@ class CPULoopOptimizer(LoopOptimizer):
         inner_loop = inner_loops(self.loop)[0]
 
         tmp = dcopy(inner_loop)
-        set_itspace(inner_loop, self.loop)
-        set_itspace(self.loop, tmp)
+        itspace_copy(inner_loop, self.loop)
+        itspace_copy(self.loop, tmp)
 
         to_transpose = set()
         if transpose:

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -180,9 +180,6 @@ class LoopOptimizer(object):
         # is triggered
         if is_perfect_loop(self.loop):
             return
-        # TODO: To be removed when supporting RHS optimization
-        if not self.exprs:
-            return
 
         # Precomputation
         do_not_precompute = set()

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -71,23 +71,16 @@ class LoopOptimizer(object):
         1. Generalized loop-invariant code motion
         2. Factorization of common loop-dependent terms
         3. Expansion of constants over loop-dependent terms
-        4. Zero-valued columns avoidance
-        5. Precomputation of integration-dependent terms
 
-        :param level: The optimization level (0, 1, 2, 3, 4). The higher, the more
+        :param level: The optimization level (0, 1, 2). The higher, the more
                       invasive is the re-writing of the expression, trying to
                       eliminate unnecessary floating point operations.
 
-                      * level == 1: performs "basic" generalized loop-invariant \
-                                    code motion
-                      * level == 2: level 1 + expansion of terms, factorization of \
-                                    basis functions appearing multiple times in the \
-                                    same expression, and finally another run of \
-                                    loop-invariant code motion to move invariant \
-                                    sub-expressions exposed by factorization
-                      * level == 3: level 2 + avoid computing zero-columns
-                      * level == 4: level 3 + precomputation of read-only expressions \
-                                    out of the loop nest
+                      * level == 1: performs generalized loop-invariant code motion only
+                      * level == 2: level 1; terms expansion (to expose factorization \
+                                    opportunities); terms factorization (to expose \
+                                    code motion opportunities); and a final pass of \
+                                    generalized loop-invariant code motion.
         """
         for stmt, expr_info in self.exprs.items():
             ew = ExpressionRewriter(stmt, expr_info, self.decls, self.header,

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -89,13 +89,13 @@ class LoopOptimizer(object):
                       * level == 4: level 3 + precomputation of read-only expressions \
                                     out of the loop nest
         """
-        for stmt_info in self.exprs.items():
-            ew = ExpressionRewriter(stmt_info, self.decls, self.header,
+        for stmt, expr_info in self.exprs.items():
+            ew = ExpressionRewriter(stmt, expr_info, self.decls, self.header,
                                     self.hoisted, self.expr_graph)
             if level > 0:
                 ew.licm()
             if level > 1:
-                if not stmt_info[1].unit_stride_loops:
+                if not expr_info.unit_stride_loops:
                     continue
                 ew.expand()
                 ew.distribute()
@@ -367,14 +367,11 @@ class CPULoopOptimizer(LoopOptimizer):
                 A[i][j] += B[i]*X[j]
         """
 
-        if not self.exprs:
-            return
-
         new_exprs = {}
         elf = ExpressionFissioner(cut)
-        for splittable in self.exprs.items():
+        for stmt, expr_info in self.exprs.items():
             # Split the expression
-            new_exprs.update(elf.fission(splittable, True))
+            new_exprs.update(elf.fission(stmt, expr_info, True))
         self.exprs = new_exprs
 
     def blas(self, library):

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -94,9 +94,7 @@ class LoopOptimizer(object):
                                     self.hoisted, self.expr_graph)
             if level > 0:
                 ew.licm()
-            if level > 1:
-                if not expr_info.domain_loops:
-                    continue
+            if level > 1 and expr_info.dimension:
                 ew.expand()
                 ew.factorize()
                 ew.licm(merge_and_simplify=True, compact_tmps=True)
@@ -396,7 +394,6 @@ class GPULoopOptimizer(LoopOptimizer):
         ``pragma coffee itspace``."""
 
         info = visit(self.loop, self.header)
-        loops = info['fors']
         symbols = info['symbols_dep']
 
         itspace_vrs = set()

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -82,6 +82,7 @@ class LoopOptimizer(object):
                                     code motion opportunities); and a final pass of \
                                     generalized loop-invariant code motion.
         """
+        ExpressionRewriter.reset()
         for stmt, expr_info in self.exprs.items():
             ew = ExpressionRewriter(stmt, expr_info, self.decls, self.header,
                                     self.hoisted, self.expr_graph)

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -37,7 +37,6 @@ from loop_scheduler import ExpressionFissioner, ZeroLoopScheduler
 from linear_algebra import LinearAlgebra
 from rewriter import ExpressionRewriter
 from ast_analyzer import ExpressionGraph, StmtTracker
-import plan
 
 
 class LoopOptimizer(object):

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -249,8 +249,7 @@ class ASTKernel(object):
                     loop_opt.unroll(dict(unroll))
 
                 # 4) Vectorization
-                if initialized:
-                    decls = dict(decls.items() + loop_opt.decls.items())
+                if initialized and loop_opt.expr_domain_loops[0]:
                     vect = LoopVectorizer(loop_opt)
                     if ap:
                         # Data alignment

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -124,7 +124,7 @@ class ASTKernel(object):
                                     for i in v.rank])
 
                 # Add iteration space arguments
-                kernel.args.extend([Decl("int", c_sym("%s" % i)) for i in itspace_vrs])
+                kernel.args.extend([Decl("int", Symbol("%s" % i)) for i in itspace_vrs])
 
             # Clean up the kernel removing variable qualifiers like 'static'
             for decl in decls.values():

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -184,7 +184,7 @@ class ASTKernel(object):
             rewrite = kwargs.get('rewrite')
             vectorize = kwargs.get('vectorize')
             v_type, v_param = vectorize if vectorize else (None, None)
-            ap = kwargs.get('align_pad')
+            align_pad = kwargs.get('align_pad')
             split = kwargs.get('split')
             toblas = kwargs.get('blas')
             unroll = kwargs.get('unroll')
@@ -251,7 +251,7 @@ class ASTKernel(object):
                 # 4) Vectorization
                 if initialized and loop_opt.expr_domain_loops[0]:
                     vect = LoopVectorizer(loop_opt)
-                    if ap:
+                    if align_pad:
                         # Data alignment
                         vect.alignment()
                         # Padding

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -50,10 +50,6 @@ from copy import deepcopy as dcopy
 import itertools
 import operator
 
-# Track the scope of a variable in the kernel
-LOCAL_VAR = 0  # Variable declared and used within the kernel
-PARAM_VAR = 1  # Variable is a kernel parameter (ie declared in the signature)
-
 
 class ASTKernel(object):
 

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -159,7 +159,7 @@ class ExpressionRewriter(object):
         # The heuristics here is that the expansion occurs along the iteration
         # variable which appears in more unique arrays. This will allow factorization
         # to be more effective.
-        itvar_occs = dict.fromkeys(self.expr_info.unit_stride_itvars, 0)
+        itvar_occs = dict.fromkeys(self.expr_info.domain, 0)
         for _, itvar in count_occurrences(self.stmt.children[1]).keys():
             if itvar and itvar[0] in itvar_occs:
                 itvar_occs[itvar[0]] += 1

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -651,8 +651,7 @@ class ExpressionExpander(object):
                 to_replace.update(hoisted)
                 to_remove.add(grp)
         ast_replace(self.stmt, to_replace, copy=True)
-        for grp in to_remove:
-            ast_remove(self.stmt, grp, 'all')
+        ast_remove(self.stmt, to_remove, 'all')
 
 
 class ExpressionFactorizer(object):

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -77,7 +77,8 @@ class ExpressionRewriter(object):
                                                 self.expr_info,
                                                 self.hoisted,
                                                 self.expr_graph)
-        self.expr_factorizer = ExpressionFactorizer(self.stmt)
+        self.expr_factorizer = ExpressionFactorizer(self.stmt,
+                                                    self.expr_info)
 
     def licm(self, merge_and_simplify=False, compact_tmps=False):
         """Perform generalized loop-invariant code motion.
@@ -656,8 +657,9 @@ class ExpressionExpander(object):
 
 class ExpressionFactorizer(object):
 
-    def __init__(self, stmt):
+    def __init__(self, stmt, expr_info):
         self.stmt = stmt
+        self.expr_info = expr_info
 
     def _find_prod(self, node, occs, factorizable):
         if isinstance(node, Symbol):

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -252,6 +252,11 @@ class ExpressionRewriter(object):
         # Perform the factorization
         self.expr_factorizer.factorize(should_factorize)
 
+    @staticmethod
+    def reset():
+        ExpressionHoister._expr_handled[:] = []
+        ExpressionExpander._expr_handled[:] = []
+
 
 class ExpressionHoister(object):
 

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -193,9 +193,12 @@ class ExpressionRewriter(object):
                      * mode == 'full': expansion is performed aggressively without \
                                        any specific restrictions.
         """
+        info = visit(self.stmt.children[1])
+        symbols_dep = info['symbols_dep']
+
         # Select the expansion strategy
         if mode == 'standard':
-            occurrences = zip(*count(self.stmt.children[1]).keys())[1]
+            occurrences = [s.rank for s in symbols_dep.keys()]
             occurrences = dict((i, occurrences.count(i)) for i in occurrences)
             dimension = max(occurrences.iteritems(), key=operator.itemgetter(1))[0]
             should_expand = lambda n: n.rank == dimension

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -174,7 +174,7 @@ class ExpressionRewriter(object):
         self.decls.update(ee.expanded_decls)
         self._expanded = True
 
-    def distribute(self):
+    def factorize(self):
         """Factorize terms in the expression.
         E.g. ::
 

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -48,18 +48,18 @@ class ExpressionRewriter(object):
     * Expansion: transform an expression ``(a + b)*c`` into ``(a*c + b*c)``
     * Factorization: transform an expression ``a*b + a*c`` into ``a*(b+c)``"""
 
-    def __init__(self, stmt_info, decls, header, hoisted, expr_graph):
+    def __init__(self, stmt, expr_info, decls, header, hoisted, expr_graph):
         """Initialize the ExpressionRewriter.
 
-        :param stmt_info: an AST node statement containing an expression and meta
-                         information (MetaExpr) related to the expression itself.
-                         including the iteration space it depends on.
-        :param decls: list of AST declarations of the various symbols in ``syms``.
+        :param stmt: AST statement containing the expression to be rewritten
+        :param expr_info: ``MetaExpr`` object describing the expression in ``stmt``
+        :param decls: declarations for the various symbols in ``stmt``.
         :param header: the parent Block of the loop in which ``stmt`` was found.
         :param hoisted: dictionary that tracks hoisted expressions
         :param expr_graph: expression graph that tracks symbol dependencies
         """
-        self.stmt, self.expr_info = stmt_info
+        self.stmt = stmt
+        self.expr_info = expr_info
         self.decls = decls
         self.header = header
         self.hoisted = hoisted

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -553,14 +553,11 @@ class ExpressionExpander(object):
         op = expansion.__class__
 
         # Is the grouped symbol hoistable, or does it break some data dependency?
-        lifted_loops = []
         for l in reversed(self.expr_info.loops):
-            lifted_loops.append(l)
+            if any([l.dim in g.rank for g in grp_symbols]):
+                return {}
             if l in hoisted_place.children:
                 break
-            for g in grp_symbols:
-                if any([l.dim in g.rank for l in lifted_loops]):
-                    return {}
 
         # The expression used for expansion is assigned to a temporary value in order
         # to minimize code size

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -36,9 +36,8 @@ from copy import deepcopy as dcopy
 import operator
 
 from base import *
+from utils import *
 from loop_scheduler import SSALoopMerger
-from utils import visit, is_perfect_loop, count_occurrences, ast_c_sum
-from utils import ast_replace, loops_as_dict, od_find_next, flatten
 import plan
 
 

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -199,7 +199,7 @@ class ExpressionRewriter(object):
         # Select the expansion strategy
         if mode == 'standard':
             occurrences = [s.rank for s in symbols_dep.keys()]
-            occurrences = dict((i, occurrences.count(i)) for i in occurrences)
+            occurrences = dict((i, occurrences.count(i)) for i in occurrences if i)
             dimension = max(occurrences.iteritems(), key=operator.itemgetter(1))[0]
             should_expand = lambda n: n.rank == dimension
         elif mode == 'full':
@@ -240,7 +240,7 @@ class ExpressionRewriter(object):
         # Select the factorization strategy
         if mode == 'standard':
             occurrences = [s.rank for s in symbols_dep.keys()]
-            occurrences = dict((i, occurrences.count(i)) for i in occurrences)
+            occurrences = dict((i, occurrences.count(i)) for i in occurrences if i)
             dimension = max(occurrences.iteritems(), key=operator.itemgetter(1))[0]
             should_factorize = lambda n: n.rank == dimension
         elif mode == 'immutable':

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -119,11 +119,11 @@ class ExpressionRewriter(object):
         # Remove temporaries created yet accessed only once
         if compact_tmps:
             stmt_occs = dict((k, v)
-                             for d in [count_occurrences(stmt, key=1, read_only=True)
+                             for d in [count(stmt, mode='symbol_id', read_only=True)
                                        for stmt in stmt_hoisted]
                              for k, v in d.items())
             for l in self.hoisted.all_loops:
-                l_occs = count_occurrences(l, key=0, read_only=True)
+                l_occs = count(l, read_only=True)
                 to_replace, to_delete = {}, []
                 for sym_rank, sym_occs in l_occs.items():
                     # If the symbol appears once, then it is a potential candidate
@@ -195,7 +195,7 @@ class ExpressionRewriter(object):
         """
         # Select the expansion strategy
         if mode == 'standard':
-            occurrences = zip(*count_occurrences(self.stmt.children[1]).keys())[1]
+            occurrences = zip(*count(self.stmt.children[1]).keys())[1]
             occurrences = dict((i, occurrences.count(i)) for i in occurrences)
             dimension = max(occurrences.iteritems(), key=operator.itemgetter(1))[0]
             should_expand = lambda n: n.rank == dimension
@@ -702,7 +702,7 @@ class ExpressionFactorizer(object):
             raise NotImplementedError("Strategy yet not implemented")
 
         factorizable = defaultdict(list)
-        occurrences = count_occurrences(self.stmt.children[1], key=2)
+        occurrences = count(self.stmt.children[1], mode='symbol_str')
         self._find_prod(self.stmt.children[1], occurrences, factorizable)
 
         if not factorizable:

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -234,9 +234,9 @@ class ExpressionRewriter(object):
         new_prods = []
         for d in to_distr.values():
             dist, target = zip(*d)
-            target = Par(ast_c_sum(target)) if len(target) > 1 else ast_c_sum(target)
+            target = Par(ast_make_sum(target)) if len(target) > 1 else ast_make_sum(target)
             new_prods.append(Par(Prod(dist[0], target)))
-        self.stmt.children[1] = Par(ast_c_sum(new_prods))
+        self.stmt.children[1] = Par(ast_make_sum(new_prods))
 
 
 class ExpressionHoister(object):

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -613,11 +613,10 @@ class ExpressionExpander(object):
         elif isinstance(node, Par):
             return self._expand(node.child, node)
 
-        elif isinstance(node, FunCall):
-            # Functions are considered potentially expandable
+        elif isinstance(node, (Div, FunCall)):
             return ([node], self.GRP)
 
-        elif isinstance(node, (Prod, Div)):
+        elif isinstance(node, Prod):
             l_exps, l_type = self._expand(node.left, node)
             r_exps, r_type = self._expand(node.right, node)
             if l_type == self.GRP and r_type == self.GRP:

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -778,10 +778,10 @@ class ExpressionFactorizer(object):
             # Finally try to factorize some of the operands composing the operation
             factorized = {}
             for t in terms:
-                operand = ast_make_expr(Prod, tuple(t.operands))
-                factor = set([t.factors_ast]) if t.factors_ast else set()
-                factorized_term = self.Term(set([operand]), factor, node.__class__)
-                _t = factorized.setdefault(str(operand), factorized_term)
+                operand = set([t.operands_ast]) if t.operands else set()
+                factor = set([t.factors_ast]) if t.factors else set()
+                factorized_term = self.Term(operand, factor, node.__class__)
+                _t = factorized.setdefault(str(t.operands_ast), factorized_term)
                 _t.factors |= factor
             factorized = ast_make_expr(Sum, [t.generate_ast for t in factorized.values()])
             parent.children[parent.children.index(node)] = factorized

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -502,8 +502,7 @@ class ExpressionHoister(object):
             place.children[ofs:ofs] = var_decl + inv_for + [FlatBlock("\n")]
             # Update hoisted symbols metadata
             for i in var_decl:
-                self.hoisted.update_stmt(i.sym.symbol, **{'loop': inv_code[0],
-                                                          'place': place})
+                self.hoisted.update_stmt(i.sym.symbol, loop=inv_code[0], place=place)
 
 
 class ExpressionExpander(object):

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -129,13 +129,12 @@ class ExpressionRewriter(object):
 
                     to_replace[str(Symbol(sym, rank))] = expr
                     to_delete.append(sym)
-
                 for stmt in l.body:
-                    symbol, expr = stmt.children
-                    sym = symbol.symbol
+                    _, expr = stmt.children
                     ast_replace(expr, to_replace, copy=True)
                 for sym in to_delete:
                     self.hoisted.delete_hoisted(sym)
+                    self.decls.pop(sym)
 
     def expand(self):
         """Expand expressions such that: ::

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -38,7 +38,6 @@ import operator
 from base import *
 from utils import *
 from loop_scheduler import SSALoopMerger
-import plan
 
 
 class ExpressionRewriter(object):

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -735,7 +735,10 @@ class ExpressionFactorizer(object):
         return children
 
     def _factorize(self, node, parent, index):
-        if isinstance(node, Par):
+        if isinstance(node, Symbol):
+            return [self.Term.process([node], self.should_factorize)]
+
+        elif isinstance(node, Par):
             return self._factorize(node.children[0], node, 0)
 
         elif isinstance(node, FunCall):

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -637,7 +637,7 @@ class ExpressionExpander(object):
                 to_replace[exp].append(expansion)
                 self.expansions.append(expansion)
             to_replace = {k: ast_make_expr(Sum, v) for k, v in to_replace.items()}
-            ast_replace(node, to_replace, copy=True, mode='symbol')
+            ast_replace(node, to_replace, mode='symbol')
             # Update the parent node, since an expression has just been expanded
             parent.children[parent.children.index(node)] = expanding_child
             return (to_replace.values() or [expanding_child], self.EXP)

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -469,7 +469,7 @@ class ExpressionHoister(object):
                     self.decls[d.sym.symbol] = d
 
                 # 5) Replace invariant sub-trees with the proper tmp variable
-                to_replace = dict(zip([str(i) for i in exprs], inv_loop_syms))
+                to_replace = dict(zip(exprs, inv_loop_syms))
                 n_replaced = ast_replace(self.stmt.children[1], to_replace)
 
                 # 6) Track hoisted symbols and symbols dependencies

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -42,7 +42,7 @@ except ImportError:
 import resource
 import operator
 from warnings import warn as warning
-from copy import deepcopy as dcopy
+from copy import deepcopy as dcopy, copy as wcopy
 from collections import defaultdict
 
 from base import *
@@ -439,7 +439,7 @@ def visit(node, parent=None, search=None, stop_on_search=False):
             access_mode = (kwargs.get('mode', READ), parent.__class__)
             dep = [l for l, _ in cur_nest if l.dim in node.rank]
             if access_mode[0] == WRITE:
-                info['symbols_written'][node.symbol] = cur_nest
+                info['symbols_written'][node.symbol] = wcopy(cur_nest)
             if node.symbol in info['symbols_written']:
                 dep = tuple(l for l, _ in info['symbols_written'][node.symbol])
             info['symbols_dep'][node] = dep

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -231,7 +231,7 @@ def ast_update_id(symbol, name, id):
 ###############################################
 
 
-def ast_c_for(stmts, loop, copy=False):
+def ast_make_for(stmts, loop, copy=False):
     """Create a for loop having the same iteration space as  ``loop`` enclosing
     the statements in  ``stmts``. If ``copy == True``, then new instances of
     ``stmts`` are created"""
@@ -243,16 +243,13 @@ def ast_c_for(stmts, loop, copy=False):
     return new_loop
 
 
-def ast_c_sum(symbols):
+def ast_make_sum(symbols):
     """Create a ``Sum`` object starting from a symbols list ``symbols``. If
-    the length of ``symbols`` is 1, return ``Symbol(symbols[0])``."""
-    if len(symbols) == 1:
-        return symbols[0]
-    else:
-        return Sum(symbols[0], ast_c_sum(symbols[1:]))
+    the length of ``symbols`` is 1, return the only symbol present."""
+    return symbols[0] if len(symbols) == 1 else Sum(symbols[0], ast_make_sum(symbols[1:]))
 
 
-def ast_c_make_alias(node1, node2):
+def ast_make_alias(node1, node2):
     """Return an object in which the LHS is represented by ``node1`` and the RHS
     by ``node2``, and ``node1`` is an alias for ``node2``; that is, ``node1``
     will point to the same memory region of ``node2``.
@@ -283,7 +280,7 @@ def ast_c_make_alias(node1, node2):
     return node1
 
 
-def ast_c_make_copy(arr1, arr2, itspace, op):
+def ast_make_copy(arr1, arr2, itspace, op):
     """Create an AST performing a copy from ``arr2`` to ``arr1``.
     Return also an ``ArrayInit`` object indicating how ``arr1`` should be
     initialized prior to the copy."""

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -429,7 +429,7 @@ def visit(node, parent=None, search=None, stop_on_search=False):
                 info['fors'].append(info['cur_nest'])
             info['cur_nest'] = info['cur_nest'][:-1]
         elif isinstance(node, Par):
-            inspect(node.children[0], node)
+            inspect(node.child, node)
         elif isinstance(node, Decl):
             node.scope = kwargs.get('scope', LOCAL)
             info['decls'][node.sym.symbol] = node

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -612,6 +612,15 @@ def itspace_from_for(loops, mode=0):
         return tuple((l.itvar, (l.start, l.end - 1)) for l in loops)
 
 
+def itspace_copy(loop_a, loop_b):
+    """Copy the iteration space of ``loop_b`` into ``loop_a``, while preserving
+    the body."""
+    loop_a.init = dcopy(loop_b.init)
+    loop_a.cond = dcopy(loop_b.cond)
+    loop_a.incr = dcopy(loop_b.incr)
+    loop_a.pragma = dcopy(loop_b.pragma)
+
+
 #############################
 # Generic utility functions #
 #############################
@@ -630,15 +639,6 @@ def insert_at_elem(list, elem, new_elem, ofs=0):
 ###########################################
 # Generic utility functions for AST loops #
 ###########################################
-
-
-def set_itspace(loop_a, loop_b):
-    """Copy the iteration space of ``loop_b`` into ``loop_a``, while preserving
-    the body."""
-    loop_a.init = dcopy(loop_b.init)
-    loop_a.cond = dcopy(loop_b.cond)
-    loop_a.incr = dcopy(loop_b.incr)
-    loop_a.pragma = dcopy(loop_b.pragma)
 
 
 def loops_as_dict(loops):

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -631,6 +631,8 @@ bind = lambda a, b: [(a, v) for v in b]
 od_find_next = lambda a, b: a.values()[a.keys().index(b)+1]
 
 
-def insert_at_elem(list, elem, new_elem, ofs=0):
-    ofs = list.index(elem) + ofs
-    list.insert(ofs, new_elem)
+def insert_at_elem(_list, elem, new_elem, ofs=0):
+    ofs = _list.index(elem) + ofs
+    new_elem = [new_elem] if not isinstance(new_elem, list) else new_elem
+    for e in reversed(new_elem):
+        _list.insert(ofs, e)

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -59,9 +59,7 @@ def increase_stack(loop_opts):
     size = 0
     for loop_opt in loop_opts:
         decls = loop_opt.decls.values()
-        if decls:
-            size += sum([reduce(operator.mul, d.sym.rank) for d in zip(*decls)[0]
-                         if d.sym.rank])
+        size += sum([reduce(operator.mul, d.sym.rank) for d in decls if d.sym.rank])
 
     if size*double_size > stack_size:
         # Increase the stack size if the kernel's stack size seems to outreach

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -312,7 +312,7 @@ def ast_c_make_copy(arr1, arr2, itspace, op):
 ###########################################################
 
 
-def visit(node, parent=None, search=None):
+def visit(node, parent=None, search=None, stop_on_search=False):
     """Explore the AST rooted in ``node`` and collect various info, including:
 
     * Loop nests encountered - a list of tuples, each tuple representing a loop nest
@@ -327,6 +327,8 @@ def visit(node, parent=None, search=None):
     :param node: AST root node of the visit
     :param parent: parent node of ``node``
     :param search: type(s) of AST nodes to be searched and tracked in the visit
+    :param stop_on_search: True if the tree visit should stop going in depth once
+                           found a node being searched, False otherwise.
     """
 
     info = {
@@ -356,6 +358,8 @@ def visit(node, parent=None, search=None):
     def inspect(node, parent, **kwargs):
         if search and isinstance(node, search):
             info['search'][type(node)].append(node)
+            if stop_on_search:
+                return
 
         if isinstance(node, EmptyStatement):
             pass

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -581,8 +581,8 @@ def itspace_to_for(itspaces, loop_parent):
     loop_body = inner_block
     for i, itspace in enumerate(itspaces):
         start, stop = itspace
-        loops.insert(0, For(Decl("int", start, c_sym(0)), Less(start, stop),
-                            Incr(start, c_sym(1)), loop_body))
+        loops.insert(0, For(Decl("int", start, Symbol(0)), Less(start, stop),
+                            Incr(start, Symbol(1)), loop_body))
         loop_body = Block([loops[i-1]], open_scope=True)
         loops_parents.append(loop_body)
     # Note that #loops_parents = #loops+1, but by zipping we just cut away the

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -350,8 +350,7 @@ def visit(node, parent=None, search=None, stop_on_search=False):
                 return
             if opts[1] == 'coffee' and opts[2] == 'expression':
                 # Found high-level optimisation
-                unit_stride_itvars = node.children[0].rank
-                return (parent, fors, unit_stride_itvars)
+                return (parent, fors, node.children[0].rank)
 
     def inspect(node, parent, **kwargs):
         if search and isinstance(node, search):

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -634,13 +634,3 @@ od_find_next = lambda a, b: a.values()[a.keys().index(b)+1]
 def insert_at_elem(list, elem, new_elem, ofs=0):
     ofs = list.index(elem) + ofs
     list.insert(ofs, new_elem)
-
-
-###########################################
-# Generic utility functions for AST loops #
-###########################################
-
-
-def loops_as_dict(loops):
-    loops_dims = [l.dim for l in loops]
-    return OrderedDict(zip(loops_dims, loops))

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -424,7 +424,7 @@ def inner_loops(node):
     def find_iloops(node, loops):
         if isinstance(node, Perfect):
             return False
-        elif isinstance(node, (Block, Root)):
+        elif isinstance(node, (Block, Root, FunDecl)):
             return any([find_iloops(s, loops) for s in node.children])
         elif isinstance(node, For):
             found = find_iloops(node.children[0], loops)

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -290,10 +290,17 @@ def ast_make_for(stmts, loop, copy=False):
     return new_loop
 
 
-def ast_make_sum(symbols):
-    """Create a ``Sum`` object starting from a symbols list ``symbols``. If
-    the length of ``symbols`` is 1, return the only symbol present."""
-    return symbols[0] if len(symbols) == 1 else Sum(symbols[0], ast_make_sum(symbols[1:]))
+def ast_make_expr(op, nodes):
+    """Create an ``Expr`` Node of type ``op``, with children given in ``nodes``."""
+
+    def _ast_make_expr(nodes):
+        return nodes[0] if len(nodes) == 1 else op(nodes[0], _ast_make_expr(nodes[1:]))
+
+    try:
+        expr = _ast_make_expr(nodes)
+        return expr if len(nodes) == 1 else Par(expr)
+    except IndexError:
+        return None
 
 
 def ast_make_alias(node1, node2):

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -620,8 +620,16 @@ def itspace_from_for(loops, mode=0):
 any_in = lambda a, b: any(i in b for i in a)
 flatten = lambda list: [i for l in list for i in l]
 bind = lambda a, b: [(a, v) for v in b]
-
 od_find_next = lambda a, b: a.values()[a.keys().index(b)+1]
+
+def insert_at_elem(list, elem, new_elem, ofs=0):
+    ofs = list.index(elem) + ofs
+    list.insert(ofs, new_elem)
+
+
+###########################################
+# Generic utility functions for AST loops #
+###########################################
 
 
 def set_itspace(loop_a, loop_b):

--- a/coffee/vectorizer.py
+++ b/coffee/vectorizer.py
@@ -441,10 +441,10 @@ class OuterProduct():
             else:
                 return decls[node_ide]
         elif isinstance(node, Par):
-            return self._vect_expr(node.children[0], ofs, regs, decls, vrs)
+            return self._vect_expr(node.child, ofs, regs, decls, vrs)
         else:
-            left = self._vect_expr(node.children[0], ofs, regs, decls, vrs)
-            right = self._vect_expr(node.children[1], ofs, regs, decls, vrs)
+            left = self._vect_expr(node.left, ofs, regs, decls, vrs)
+            right = self._vect_expr(node.right, ofs, regs, decls, vrs)
             if isinstance(node, Sum):
                 return plan.isa["add"](left, right)
             elif isinstance(node, Sub):

--- a/coffee/vectorizer.py
+++ b/coffee/vectorizer.py
@@ -44,18 +44,22 @@ class VectStrategy():
 
     """Supported vectorization modes."""
 
-    # Generate scalar code suitable to compiler auto-vectorization
+    """Generate scalar code suitable to compiler auto-vectorization"""
     AUTO = 1
-    # Specialized (intrinsics-based) vectorization using padding
+
+    """Specialized (intrinsics-based) vectorization using padding"""
     SPEC_PADD = 2
-    # Specialized (intrinsics-based) vectorization using peel loop
+
+    """Specialized (intrinsics-based) vectorization using peel loop"""
     SPEC_PEEL = 3
-    # Specialized (intrinsics-based) vectorization composed with unroll-and-jam
-    # of outer loops, padding (to enforce data alignment), and peeling of padded
-    # iterations.
+
+    """Specialized (intrinsics-based) vectorization composed with unroll-and-jam
+    of outer loops, padding (to enforce data alignment), and peeling of padded
+    iterations"""
     SPEC_UAJ_PADD = 4
-    # Specialized (intrinsics-based) vectorization composed with unroll-and-jam
-    # of outer loops and padding (to enforce data alignment).
+
+    """Specialized (intrinsics-based) vectorization composed with unroll-and-jam
+    of outer loops and padding (to enforce data alignment)"""
     SPEC_UAJ_PADD_FULL = 5
 
 

--- a/coffee/vectorizer.py
+++ b/coffee/vectorizer.py
@@ -181,7 +181,7 @@ class LoopVectorizer(object):
             for s_p_itspace, binding in itspace_binding.items():
                 s_refs, b_refs = zip(*binding)
                 if first[0] == READ:
-                    copy, init = ast_c_make_copy(b_refs, s_refs, s_p_itspace, Assign)
+                    copy, init = ast_make_copy(b_refs, s_refs, s_p_itspace, Assign)
                     header.children.insert(0, copy.children[0])
                 if last[0] == WRITE:
                     # If extra information (i.e., a pragma) is present telling that
@@ -194,7 +194,7 @@ class LoopVectorizer(object):
                     if ext_acc_mode and ext_acc_mode[0] == WRITE and \
                             len(itspace_binding) == 1:
                         op = Assign
-                    copy, init = ast_c_make_copy(s_refs, b_refs, s_p_itspace, op)
+                    copy, init = ast_make_copy(s_refs, b_refs, s_p_itspace, op)
                     if to_invert:
                         insert_at_elem(header.children, to_invert, copy.children[0])
                     else:


### PR DESCRIPTION
A number of features with this PR:
- Allow optimisation of generic tensor expressions (in firedrake language: we can optimise 0 and 1 forms) 
- Complete refactoring of two key operations performed by the Expression Rewriter: expansion and factorisation.
- Rewrite obsolete code with higher quality code
- Drop useless stuff
- Minor fixes
 
Must land with ffc PR 74 and pyop2 PR 437