### PR TITLE
Tree visitor infrastructure

### DIFF
--- a/coffee/base.py
+++ b/coffee/base.py
@@ -63,21 +63,6 @@ ternary = lambda e, s1, s2: wrap("%s ? %s : %s" % (e, s1, s2))
 as_symbol = lambda s: s if isinstance(s, Node) else Symbol(s)
 
 
-# Meta classes for semantic decoration of AST nodes ##
-
-
-class Perfect(object):
-    """Dummy mixin class used to decorate classes which can form part
-    of a perfect loop nest."""
-    pass
-
-
-class LinAlg(object):
-    """Dummy mixin class used to decorate classes which represent linear
-    algebra operations."""
-    pass
-
-
 # Base classes of the AST ###
 
 
@@ -137,6 +122,21 @@ class Root(Node):
     def gencode(self):
         header = '// This code is generated visiting a COFFEE AST\n\n'
         return header + Node.gencode(self)
+
+
+# Meta classes for semantic decoration of AST nodes ##
+
+
+class Perfect(Node):
+    """Dummy mixin class used to decorate classes which can form part
+    of a perfect loop nest."""
+    pass
+
+
+class LinAlg(Node):
+    """Dummy mixin class used to decorate classes which represent linear
+    algebra operations."""
+    pass
 
 
 # Expressions ###

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -90,6 +90,19 @@ class Node(object):
         # Pragmas are used to attach semantical information to nodes
         self._pragma = self._format_pragma(pragma)
 
+    def reconstruct(self, *args, **kwargs):
+        """Return a new instance of this :class:`Node`.
+
+        :arg args: positional arguments to the constructor.
+        :arg kwargs: keyword arguments to the constructor.
+        """
+        return type(self)(*args, **kwargs)
+
+    def operands(self):
+        """Return the operands of this :class:`Node` as an iterable,
+        along with a :class:`dict` of keyword arguments (the pragma decorator)."""
+        return self.children, {'pragma': self.pragma}
+
     def gencode(self):
         return "\n".join([n.gencode() for n in self.children])
 
@@ -139,9 +152,11 @@ class BinExpr(Expr):
 
     """Generic binary expression."""
 
-    def __init__(self, expr1, expr2, op):
+    def __init__(self, expr1, expr2):
         super(BinExpr, self).__init__([expr1, expr2])
-        self.op = op
+
+    def reconstruct(self, expr1, expr2, **kwargs):
+        return type(self)(expr1, expr2, **kwargs)
 
     def __deepcopy__(self, memo):
         """Binary expressions always need to be copied as plain new objects,
@@ -151,7 +166,7 @@ class BinExpr(Expr):
         return self.__class__(dcopy(self.children[0]), dcopy(self.children[1]))
 
     def gencode(self, not_scope=True, parent=None):
-        subtree = (" "+self.op+" ").join([n.gencode(not_scope, self) for n in self.children])
+        subtree = (" "+type(self).op+" ").join([n.gencode(not_scope) for n in self.children])
         if parent and not isinstance(parent, (Par, self.__class__)):
             return wrap(subtree)
         return subtree
@@ -172,6 +187,12 @@ class UnaryExpr(Expr):
     def __init__(self, expr):
         super(UnaryExpr, self).__init__([expr])
 
+    def reconstruct(self, expr, **kwargs):
+        return type(self)(expr, **kwargs)
+
+    def gencode(self, not_scope=True, parent=None):
+        return "%s%s" % (type(self).op, self.children[0].gencode(not_scope)) + semicolon(not_scope)
+
     def __deepcopy__(self, memo):
         """Unary expressions always need to be copied as plain new objects,
         ignoring whether they have been copied before; that is, the ``memo``
@@ -185,10 +206,13 @@ class UnaryExpr(Expr):
 
 
 class Neg(UnaryExpr):
+    """Unary negation of an expression"""
+    op = "-"
 
-    "Unary negation of an expression"
-    def gencode(self, not_scope=False, parent=None):
-        return "-%s" % wrap(self.child.gencode(not_scope, self)) + semicolon(not_scope)
+
+class Not(UnaryExpr):
+    """Compare an expression to ``NULL`` using the operator ``!``."""
+    op = "!"
 
 
 class ArrayInit(Expr):
@@ -203,6 +227,12 @@ class ArrayInit(Expr):
 
     def __init__(self, values):
         self.values = values
+
+    def reconstruct(self, values, **kwargs):
+        return type(self)(values, **kwargs)
+
+    def operands(self):
+        return [self.values], {}
 
     def gencode(self, not_scope=True, parent=None):
         return self.values
@@ -224,6 +254,12 @@ class ColSparseArrayInit(ArrayInit):
         self.nonzero_bounds = nonzero_bounds
         self.numpy_values = numpy_values
 
+    def reconstruct(self, values, nonzero_bounds, numpy_values, **kwargs):
+        return type(self)(values, nonzero_bounds, numpy_values, **kwargs)
+
+    def operands(self):
+        return [self.values, self.nonzero_bounds, self.numpy_values], {}
+
     def gencode(self, not_scope=True, parent=None):
         return self.values
 
@@ -237,94 +273,53 @@ class Par(UnaryExpr):
 
 
 class Sum(BinExpr):
-
     """Binary sum."""
-
-    def __init__(self, expr1, expr2):
-        super(Sum, self).__init__(expr1, expr2, "+")
+    op = "+"
 
 
 class Sub(BinExpr):
-
     """Binary subtraction."""
-
-    def __init__(self, expr1, expr2):
-        super(Sub, self).__init__(expr1, expr2, "-")
+    op = "-"
 
 
 class Prod(BinExpr):
-
     """Binary product."""
-
-    def __init__(self, expr1, expr2):
-        super(Prod, self).__init__(expr1, expr2, "*")
+    op = "*"
 
 
 class Div(BinExpr):
-
     """Binary division."""
-
-    def __init__(self, expr1, expr2):
-        super(Div, self).__init__(expr1, expr2, "/")
+    op = "/"
 
 
 class Eq(BinExpr):
-
     """Compare two expressions using the operand ``==``."""
-
-    def __init__(self, expr1, expr2):
-        super(Eq, self).__init__(expr1, expr2, "==")
+    op = "=="
 
 
 class NEq(BinExpr):
-
     """Compare two expressions using the operand ``!=``."""
-
-    def __init__(self, expr1, expr2):
-        super(NEq, self).__init__(expr1, expr2, "!=")
+    op = "!="
 
 
 class Less(BinExpr):
-
     """Compare two expressions using the operand ``<``."""
-
-    def __init__(self, expr1, expr2):
-        super(Less, self).__init__(expr1, expr2, "<")
+    op = "<"
 
 
 class LessEq(BinExpr):
-
     """Compare two expressions using the operand ``<=``."""
-
-    def __init__(self, expr1, expr2):
-        super(LessEq, self).__init__(expr1, expr2, "<=")
+    op = "<="
 
 
 class Greater(BinExpr):
-
     """Compare two expressions using the operand ``>``."""
-
-    def __init__(self, expr1, expr2):
-        super(Greater, self).__init__(expr1, expr2, ">")
+    op = ">"
 
 
 class GreaterEq(BinExpr):
-
     """Compare two expressions using the operand ``>=``."""
-
-    def __init__(self, expr1, expr2):
-        super(GreaterEq, self).__init__(expr1, expr2, ">=")
-
-
-class Not(UnaryExpr):
-
-    """Compare an expression to ``NULL`` using the operator ``!``."""
-
-    def __init__(self, expr):
-        super(Not, self).__init__(expr)
-
-    def gencode(self, not_scope=True, parent=None):
-        return "!%s" % self.child.gencode(not_scope, self)
+    op = ">="
 
 
 class FunCall(Expr, Perfect):
@@ -334,6 +329,12 @@ class FunCall(Expr, Perfect):
     def __init__(self, function_name, *args):
         super(Expr, self).__init__(args)
         self.funcall = as_symbol(function_name)
+
+    def reconstruct(self, *args, **kwargs):
+        return type(self)(*args, **kwargs)
+
+    def operands(self):
+        return [self.funcall] + self.children, {}
 
     def gencode(self, not_scope=False, parent=None):
         return self.funcall.gencode() + \
@@ -347,8 +348,11 @@ class Ternary(Expr):
     def __init__(self, expr, true_stmt, false_stmt):
         super(Ternary, self).__init__([expr, true_stmt, false_stmt])
 
+    def reconstruct(self, *args, **kwargs):
+        return type(self)(*args, **kwargs)
+
     def gencode(self, not_scope=True, parent=None):
-        return ternary(*[c.gencode(True, self) for c in self.children]) + \
+        return ternary(*[c.gencode(True) for c in self.children]) + \
             semicolon(not_scope)
 
 
@@ -370,6 +374,9 @@ class Symbol(Expr):
         self.rank = rank
         self.offset = offset
 
+    def operands(self):
+        return [self.symbol, self.rank, self.offset], {}
+
     def gencode(self, not_scope=True, parent=None):
         points = ""
         if not self.offset:
@@ -388,41 +395,32 @@ class Symbol(Expr):
 
 # Vector expression classes ###
 
+class AVXBinOp(BinExpr):
 
-class AVXSum(Sum):
+    def gencode(self, not_scope=True):
+        op1 = self.children[0]
+        op2 = self.children[1]
+        return "%s(%s, %s)" % (type(self).op, op1.gencode(), op2.gencode())
 
+
+class AVXSum(AVXBinOp, Sum):
     """Sum of two vector registers using AVX intrinsics."""
-
-    def gencode(self, not_scope=True):
-        op1, op2 = self.children
-        return "_mm256_add_pd (%s, %s)" % (op1.gencode(), op2.gencode())
+    op = "_mm256_add_pd"
 
 
-class AVXSub(Sub):
-
+class AVXSub(AVXBinOp, Sub):
     """Subtraction of two vector registers using AVX intrinsics."""
-
-    def gencode(self, not_scope=True):
-        op1, op2 = self.children
-        return "_mm256_sub_pd (%s, %s)" % (op1.gencode(), op2.gencode())
+    op = "mm256_sub_pd"
 
 
-class AVXProd(Prod):
-
+class AVXProd(AVXBinOp, Prod):
     """Product of two vector registers using AVX intrinsics."""
-
-    def gencode(self, not_scope=True):
-        op1, op2 = self.children
-        return "_mm256_mul_pd (%s, %s)" % (op1.gencode(), op2.gencode())
+    op = "_mm256_mul_pd"
 
 
-class AVXDiv(Div):
-
+class AVXDiv(AVXBinOp, Div):
     """Division of two vector registers using AVX intrinsics."""
-
-    def gencode(self, not_scope=True):
-        op1, op2 = self.children
-        return "_mm256_div_pd (%s, %s)" % (op1.gencode(), op2.gencode())
+    op = "_mm256_div_pd"
 
 
 class AVXLoad(Symbol):
@@ -477,8 +475,8 @@ class FlatBlock(Statement, Perfect):
     """Treat a chunk of code as a single statement, i.e. a C string"""
 
     def __init__(self, code, pragma=None):
-        Statement.__init__(self, pragma)
-        self.children.append(code)
+        self.pragma = pragma
+        self.children = [code]
 
     def gencode(self, not_scope=False):
         return self.children[0]
@@ -496,55 +494,34 @@ class Assign(Statement, Perfect):
                       self.children[1].gencode()) + semicolon(not_scope)
 
 
-class Incr(Statement, Perfect):
+class AugmentedAssign(Statement, Perfect):
 
+    def __init__(self, sym, exp, pragma=None):
+        super(AugmentedAssign, self).__init__([sym, exp], pragma)
+
+    def gencode(self, not_scope=False):
+        sym, exp = self.children
+        return "%s %s %s%s" % (sym.gencode(), type(self).op, exp.gencode(), semicolon(not_scope))
+
+
+class Incr(AugmentedAssign):
     """Increment a symbol by an expression."""
-
-    def __init__(self, sym, exp, pragma=None):
-        super(Incr, self).__init__([sym, exp], pragma)
-
-    def gencode(self, not_scope=False):
-        sym, exp = self.children
-        if isinstance(exp, Symbol) and exp.symbol == 1:
-            return incr_by_1(sym.gencode()) + semicolon(not_scope)
-        else:
-            return incr(sym.gencode(), exp.gencode()) + semicolon(not_scope)
+    op = "+="
 
 
-class Decr(Statement, Perfect):
-
+class Decr(AugmentedAssign):
     """Decrement a symbol by an expression."""
-    def __init__(self, sym, exp, pragma=None):
-        super(Decr, self).__init__([sym, exp], pragma)
-
-    def gencode(self, not_scope=False):
-        sym, exp = self.children
-        if isinstance(exp, Symbol) and exp.symbol == 1:
-            return decr_by_1(sym.gencode()) + semicolon(not_scope)
-        else:
-            return decr(sym.gencode(), exp.gencode()) + semicolon(not_scope)
+    op = "-="
 
 
-class IMul(Statement, Perfect):
-
+class IMul(AugmentedAssign):
     """In-place multiplication of a symbol by an expression."""
-    def __init__(self, sym, exp, pragma=None):
-        super(IMul, self).__init__([sym, exp], pragma)
-
-    def gencode(self, not_scope=False):
-        sym, exp = self.children
-        return imul(sym.gencode(), exp.gencode()) + semicolon(not_scope)
+    op = "*="
 
 
-class IDiv(Statement, Perfect):
-
+class IDiv(AugmentedAssign):
     """In-place division of a symbol by an expression."""
-    def __init__(self, sym, exp, pragma=None):
-        super(IDiv, self).__init__([sym, exp], pragma)
-
-    def gencode(self, not_scope=False):
-        sym, exp = self.children
-        return idiv(sym.gencode(), exp.gencode()) + semicolon(not_scope)
+    op = "/="
 
 
 class Decl(Statement, Perfect):
@@ -566,6 +543,9 @@ class Decl(Statement, Perfect):
         self.qual = qualifiers or []
         self.attr = attributes or []
         self.init = as_symbol(init) if init is not None else EmptyStatement()
+
+    def operands(self):
+        return [self.typ, self.sym, self.init, self.qual, self.attr], {}
 
     @property
     def size(self):
@@ -631,13 +611,19 @@ class Block(Statement):
 
     """Block of statements."""
 
-    def __init__(self, stmts, pragma=None, open_scope=False):
+    def __init__(self, stmts, pragma=None, open_scope=None):
         if len(stmts) == 1 and isinstance(stmts[0], Block):
             # Avoid nesting of blocks
             super(Block, self).__init__(stmts[0].children, pragma)
         else:
             super(Block, self).__init__(stmts, pragma)
         self.open_scope = open_scope
+
+    def reconstruct(self, *stmts, **kwargs):
+        return type(self)(stmts, **kwargs)
+
+    def operands(self):
+        return self.children, {'pragma': self.pragma, 'open_scope': self.open_scope}
 
     def gencode(self, not_scope=False):
         code = "".join([n.gencode(not_scope) for n in self.children])
@@ -665,6 +651,12 @@ class For(Statement):
         self.init = init
         self.cond = cond
         self.incr = incr
+
+    def operands(self):
+        return [self.init, self.cond, self.incr, self.children[0]], {'pragma': self.pragma}
+
+    def reconstruct(self, init, cond, incr, body, **kwargs):
+        return type(self)(init, cond, incr, body, **kwargs)
 
     @property
     def dim(self):
@@ -722,6 +714,12 @@ class Switch(Statement):
         self.switch_expr = switch_expr
         self.cases = cases
 
+    def operands(self):
+        return [self.switch_expr, self.cases], {}
+
+    def reconstruct(self, expr, cases, **kwargs):
+        return type(self)(expr, cases, **kwargs)
+
     def gencode(self):
         return "switch (" + str(self.switch_expr) + ")\n{\n" \
             + indent("\n".join("case %s: \n{\n%s\n}" % (str(i), indent(str(s)))
@@ -739,6 +737,12 @@ class If(Statement):
     def __init__(self, if_expr, branches):
         super(If, self).__init__(branches)
         self.if_expr = if_expr
+
+    def operands(self):
+        return [self.if_expr, self.children], {}
+
+    def reconstruct(self, expr, branches, **kwargs):
+        return type(self)(expr, branches, **kwargs)
 
     def gencode(self, not_scope=False):
         else_branch = ""
@@ -766,6 +770,12 @@ class FunDecl(Statement):
         self.name = name
         self.args = args
         self.headers = headers or []
+
+    def operands(self):
+        return [self.ret, self.name, self.args, self.children[0], self.pred, self.headers], {}
+
+    def reconstruct(self, ret, name, args, body, pred, headers, **kwargs):
+        return type(self)(ret, name, args, body, pred, headers, **kwargs)
 
     @property
     def body(self):
@@ -806,6 +816,12 @@ class AVXLocalPermute(Statement):
         self.r = r
         self.mask = mask
 
+    def reconstruct(self, r, mask, **kwargs):
+        return type(self)(r, mask, **kwargs)
+
+    def operands(self):
+        return [self.r, self.mask], {}
+
     def gencode(self, not_scope=True):
         op = self.r.gencode()
         return "_mm256_permute_pd (%s, %s)" \
@@ -822,6 +838,12 @@ class AVXGlobalPermute(Statement):
         self.r2 = r2
         self.mask = mask
 
+    def reconstruct(self, r1, r2, mask, **kwargs):
+        return type(self)(r1, r2, mask, **kwargs)
+
+    def operands(self):
+        return [self.r1, self.r2, self.mask], {}
+
     def gencode(self, not_scope=True):
         op1 = self.r1.gencode()
         op2 = self.r2.gencode()
@@ -829,34 +851,35 @@ class AVXGlobalPermute(Statement):
             % (op1, op2, self.mask) + semicolon(not_scope)
 
 
-class AVXUnpackHi(Statement):
+class AVXUnpack(Statement):
+    def __init__(self, r1, r2):
+        self.r1 = r1
+        self.r2 = r2
+
+    def reconstruct(self, r1, r2, **kwargs):
+        return type(self)(r1, r2, **kwargs)
+
+    def operands(self):
+        return [self.r1, self.r2], {}
+
+    def gencode(self, not_scope=True):
+        op1 = self.r1.gencode()
+        op2 = self.r2.gencode()
+        return "%s(%s, %s)" % (type(self).op, op1, op2) + semicolon(not_scope)
+
+
+class AVXUnpackHi(AVXUnpack):
 
     """Unpack of values in a vector register using AVX intrinsics.
     The intrinsic function used is ``_mm256_unpackhi_pd``."""
-
-    def __init__(self, r1, r2):
-        self.r1 = r1
-        self.r2 = r2
-
-    def gencode(self, not_scope=True):
-        op1 = self.r1.gencode()
-        op2 = self.r2.gencode()
-        return "_mm256_unpackhi_pd (%s, %s)" % (op1, op2) + semicolon(not_scope)
+    op = "_mm256_unpackhi_pd"
 
 
-class AVXUnpackLo(Statement):
+class AVXUnpackLo(AVXUnpack):
 
     """Unpack of values in a vector register using AVX intrinsics.
     The intrinsic function used is ``_mm256_unpacklo_pd``."""
-
-    def __init__(self, r1, r2):
-        self.r1 = r1
-        self.r2 = r2
-
-    def gencode(self, not_scope=True):
-        op1 = self.r1.gencode()
-        op2 = self.r2.gencode()
-        return "_mm256_unpacklo_pd (%s, %s)" % (op1, op2) + semicolon(not_scope)
+    op = "_mm256_unpacklo_pd"
 
 
 class AVXSetZero(Statement):
@@ -864,6 +887,7 @@ class AVXSetZero(Statement):
     """Set to 0 the entries of a vector register using AVX intrinsics."""
 
     def gencode(self, not_scope=True):
+        # mm256_setzero_pd takes no arguments and returns zeroed vector register
         return "_mm256_setzero_pd ()" + semicolon(not_scope)
 
 
@@ -874,6 +898,12 @@ class Invert(Statement, Perfect, LinAlg):
     """In-place inversion of a square array."""
     def __init__(self, sym, dim, pragma=None):
         super(Invert, self).__init__([sym, dim, dim], pragma)
+
+    def reconstruct(self, sym, dim, **kwargs):
+        return type(self)(sym, dim, **kwargs)
+
+    def operands(self):
+        return [self.children[0], self.children[1]], {'pragma': self.pragma}
 
     def gencode(self, not_scope=True):
         sym, dim, lda = self.children
@@ -891,22 +921,37 @@ class Invert(Statement, Perfect, LinAlg):
 """ % (str(dim), str(lda), str(sym), str(sym))
 
 
-class Determinant1x1(Expr, Perfect, LinAlg):
+class Determinant(Expr, Perfect, LinAlg):
+    """Generic determinant"""
+    def __init__(self, sym, pragma=None):
+        super(Determinant, self).__init__([sym, type(self).dim, type(self).lda], pragma=pragma)
+
+    def reconstruct(self, sym, **kwargs):
+        return type(self)(sym, **kwargs)
+
+    def operands(self):
+        return self.children[0], {}
+
+    def gencode(self):
+        raise NotImplementedError("Not implemented")
+
+
+class Determinant1x1(Determinant):
 
     """Determinant of a 1x1 square array."""
-    def __init__(self, sym, pragma=None):
-        super(Determinant1x1, self).__init__([sym, 2, 2])
+    dim = 2
+    lda = 2
 
     def gencode(self, scope=False):
         sym, dim, lda = self.children
         return Symbol(sym.gencode(), (0, 0))
 
 
-class Determinant2x2(Expr, Perfect, LinAlg):
+class Determinant2x2(Determinant):
 
     """Determinant of a 2x2 square array."""
-    def __init__(self, sym, pragma=None):
-        super(Determinant2x2, self).__init__([sym, 2, 2])
+    dim = 2
+    lda = 2
 
     def gencode(self, scope=False):
         sym, dim, lda = self.children
@@ -918,8 +963,8 @@ class Determinant2x2(Expr, Perfect, LinAlg):
 class Determinant3x3(Expr, Perfect, LinAlg):
 
     """Determinant of a 3x3 square array."""
-    def __init__(self, sym, pragma=None):
-        super(Determinant3x3, self).__init__([sym, 2, 2])
+    dim = 2
+    lda = 2
 
     def gencode(self, scope=False):
         sym, dim, lda = self.children
@@ -944,6 +989,9 @@ class PreprocessNode(Node):
 
     def __init__(self, prep):
         super(PreprocessNode, self).__init__([prep])
+
+    def reconstruct(self, prep, **kwargs):
+        return type(self)(prep, **kwargs)
 
     def gencode(self, not_scope=False):
         return self.children[0].gencode()

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -47,6 +47,7 @@ from warnings import warn as warning
 from base import *
 from utils import *
 from expression import MetaExpr, copy_metaexpr
+from coffee.visitors import FindLoopNests
 
 
 class LoopScheduler(object):
@@ -140,7 +141,7 @@ class SSALoopMerger(LoopScheduler):
         for n in self.root.children:
             if isinstance(n, For):
                 # Track structure of iteration spaces
-                loops_infos = visit(n, self.root)['fors']
+                loops_infos = FindLoopNests().visit(n, {'node_parent': self.root})
                 for li in loops_infos:
                     loops, loops_parents = zip(*li)
                     # Note that only inner loops can be fused, and that they share

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -37,6 +37,7 @@ from loop_scheduler import ExpressionFissioner, ZeroLoopScheduler
 from linear_algebra import LinearAlgebra
 from rewriter import ExpressionRewriter
 from ast_analyzer import ExpressionGraph, StmtTracker
+from coffee.visitors import MaxLoopDepth
 
 
 class LoopOptimizer(object):
@@ -366,7 +367,7 @@ class CPULoopOptimizer(LoopOptimizer):
         algebra libraries. Currently, MKL, ATLAS, and EIGEN are supported."""
 
         # First, check that the loop nest has depth 3, otherwise it's useless
-        if visit(self.loop, self.header)['max_depth'] != 3:
+        if MaxLoopDepth().visit(self.loop) != 3:
             return
 
         linear_algebra = LinearAlgebra(self.loop, self.header, self.kernel_decls)

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -45,6 +45,7 @@ from optimizer import CPULoopOptimizer, GPULoopOptimizer
 from vectorizer import LoopVectorizer, VectStrategy
 from autotuner import Autotuner
 from expression import MetaExpr
+from coffee.visitors import FindInstances
 
 from copy import deepcopy as dcopy
 import itertools
@@ -94,7 +95,7 @@ class ASTKernel(object):
 
         # The optimization passes are performed individually (i.e., "locally") for
         # each function (or "kernel") found in the provided AST
-        kernels = visit(self.ast, search=FunDecl, stop_on_search=True)['search'][FunDecl]
+        kernels = FindInstances(FunDecl, stop_when_found=True).visit(self.ast)[FunDecl]
         for kernel in kernels:
             info = visit(kernel)
             decls = info['decls']
@@ -272,7 +273,7 @@ class ASTKernel(object):
 
             return loop_opts
 
-        kernels = visit(self.ast, search=FunDecl, stop_on_search=True)['search'][FunDecl]
+        kernels = FindInstances(FunDecl, stop_when_found=True).visit(self.ast)[FunDecl]
         if opts.get('autotune'):
             if not (compiler and isa):
                 raise RuntimeError("Must initialize COFFEE prior to autotuning")

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -39,6 +39,7 @@ import itertools
 from base import *
 from utils import *
 from loop_scheduler import SSALoopMerger
+from coffee.visitors import SymbolReferences
 
 
 class ExpressionRewriter(object):
@@ -564,7 +565,7 @@ class ExpressionExpander(object):
         op = expansion.__class__
 
         # Is the grouped symbol hoistable, or does it break some data dependency?
-        grp_symbols = visit(grp)['symbol_refs'].keys()
+        grp_symbols = SymbolReferences().visit(grp).keys()
         for l in reversed(self.expr_info.loops):
             for g in grp_symbols:
                 g_refs = self.info['symbol_refs'][g]

--- a/coffee/vectorizer.py
+++ b/coffee/vectorizer.py
@@ -38,6 +38,7 @@ from collections import defaultdict
 from base import *
 from utils import *
 import plan
+from coffee.visitors import FindInstances
 
 
 class VectStrategy():
@@ -85,11 +86,15 @@ class LoopVectorizer(object):
         # Aliases
         decls = self.loop_opt.decls
         header = self.loop_opt.header
-        info = visit(header, search=LinAlg)
+        info = visit(header)
         symbols_dep = info['symbols_dep']
         symbols_mode = info['symbols_mode']
         symbol_refs = info['symbol_refs']
-        to_invert = info['search'][Invert][0] if info['search'][Invert] else None
+        to_invert = FindInstances(Invert).visit(header)[Invert]
+        if len(to_invert) > 1:
+            raise NotImplementedError("More than one Invert node not handled")
+        if to_invert:
+            to_invert = to_invert[0]
 
         # 0) Under some circumstances, do not apply padding
         # A- Loop increments must be equal to 1, because at the moment the

--- a/coffee/visitor.py
+++ b/coffee/visitor.py
@@ -36,6 +36,30 @@ class Environment(object):
         except KeyError:
             return self.parent[key]
 
+    def __repr__(self):
+        mappings = ", ".join("%s=%r" % (k, v) for (k, v) in self.mapping.iteritems())
+        return "Environment(parent=%r, %s)" % (self.parent, mappings)
+
+    def __str__(self):
+        dicts = []
+        # Walk up stack, gathering mappings.
+        while True:
+            try:
+                dicts.append(self.mapping)
+            except AttributeError:
+                # Hit top of stack
+                dicts.append(self)
+                break
+            self = self.parent
+        # Build environment from root down to self for printing
+        vals = {}
+        while True:
+            try:
+                vals.update(dicts.pop())
+            except IndexError:
+                break
+        return "Environment: %s" % vals
+
 
 class Visitor(object):
 

--- a/coffee/visitor.py
+++ b/coffee/visitor.py
@@ -1,0 +1,165 @@
+from __future__ import absolute_import
+import inspect
+
+__all__ = ["Environment", "Visitor"]
+
+
+class Environment(object):
+
+    """
+    An environment containing state.
+
+    This is effectively a dictionary that looks up unknown keys in a
+    parent.  It only implements :data:`__getitem__`, and
+    :data:`__setitem__` and exposes the
+    dict directly as :attr:`mapping`.
+
+    Used to implement "stacked" environments in :class:`Visitor`\s.
+
+    :arg parent: The parent environment (pass an empty dict as an
+         empty environment).
+    :kwargs kwargs: values to set in the environment.
+    """
+
+    def __init__(self, parent, **kwargs):
+        super(Environment, self).__init__()
+        self.parent = parent
+        self.mapping = dict(**kwargs)
+
+    def __getitem__(self, key):
+        """Look up an item in this :class:`Environment`.
+
+        :arg key: The item to look up.
+        """
+        try:
+            return self.mapping[key]
+        except KeyError:
+            return self.parent[key]
+
+
+class Visitor(object):
+
+    """
+    A generic visitor for a COFFEE AST.
+
+    To define handlers, subclasses should define :data:`visit_Foo`
+    methods for each class :data:`Foo` they want to handle.
+
+    If a specific method for a class :data:`Foo` is not found, the MRO
+    of the class is walked in order until a matching method is found.
+
+    Pre- and post-order traversal is implemented in a single
+    :meth:`visit` method, with the argument list for a method handler
+    indicating if it expects transformed children or not.
+
+    The two method signatures are:
+
+    .. code-block::
+
+       def visit_Foo(self, o, env):
+           pass
+
+    for pre-order traversal, in which case the handler should take
+    care to traverse the children if necessary.  And:
+
+    .. code-block::
+
+       def visit_Foo(self, o, env, *args, **kwargs):
+           pass
+
+    for post-order traversal, in which case handlers will be called on
+    the children first and passed in through :data:`*args`.
+    :data:`**kwargs` will contain any keyword arguments that were used
+    in the construction of the instance, see
+    :meth:`~.Node.reconstruct` and :meth:`~.Node.operands` for more details.
+
+    In both cases, the instance itself is passed in as :data:`o` and
+    the visitor also receives a :class:`Environment` object in
+    :data:`env` which it may inspect if wished.
+
+    """
+    def __init__(self):
+
+        handlers = {}
+        # visit methods are spelt visit_Foo.
+        prefix = "visit_"
+        # Inspect the methods on this instance to find out which
+        # handlers are defined.
+        for (name, meth) in inspect.getmembers(self, predicate=inspect.ismethod):
+            if not name.startswith(prefix):
+                continue
+            # Check the argument specification
+            # Valid options are:
+            #    visit_Foo(self, o, env)
+            # or
+            #    visit_Foo(self, o, env, *args, **kwargs)
+            #
+            # The latter indicates that the visit handler expects
+            # the children to have already been visited, the
+            # former indicates that the method will handle it
+            # itself.
+            argspec = inspect.getargspec(meth)
+            if len(argspec.args) != 3:
+                raise RuntimeError("Visit method signature must be visit_Foo(self, o, env, [*args, **kwargs])")
+            children_first = argspec.varargs is not None
+            if children_first and argspec.keywords is None:
+                raise RuntimeError("Post-order visitor must be visit_Foo(self, o, env, *args, **kwargs)")
+            handlers[name[len(prefix):]] = (meth, children_first)
+        self._handlers = handlers
+
+    def lookup_method(self, instance):
+        """Look up a handler method for a visitee.
+
+        :arg instance: The instance to look up a method for.
+        """
+        cls = instance.__class__
+        try:
+            # Do we have a method handler defined for this type name
+            return self._handlers[cls.__name__]
+        except KeyError:
+            # No, walk the MRO.
+            for klass in cls.mro()[1:]:
+                entry = self._handlers.get(klass.__name__)
+                if entry:
+                    # Save it on this type name for faster lookup next time
+                    self._handlers[cls.__name__] = entry
+                    return entry
+        raise RuntimeError("No handler found for class %s", cls.__name__)
+
+    def visit(self, o, env=None):
+        """Apply this :class:`Visitor` to an AST.
+
+        :arg o: The :class:`Node` to visit.
+        :arg env: An optional :class:`Environment` to pass to the
+             visitor.
+        """
+        meth, children_first = self.lookup_method(o)
+
+        if env is None:
+            # Default to empty environment
+            env = {}
+
+        if children_first:
+            # Visit children then call handler on us
+            ops, kwargs = o.operands()
+            return meth(o, env, *[self.visit(op, env=env) for op in ops], **kwargs)
+        else:
+            # Handler deals with children
+            return meth(o, env)
+
+    def reuse(self, o, env):
+        """A visit method to reuse a node, ignoring children."""
+        return o
+
+    def maybe_reconstruct(self, o, env, *args, **kwargs):
+        """A visit method that reconstructs nodes if their children
+        have changed."""
+        oargs, okwargs = o.operands()
+        if all(a is b for a, b in zip(oargs, args)) and \
+           okwargs == kwargs:
+            return o
+        return o.reconstruct(*args, **kwargs)
+
+    def always_reconstruct(self, o, env, *args, **kwargs):
+        """A visit method that always reconstructs nodes."""
+        return o.reconstruct(*args, **kwargs)

--- a/coffee/visitors/__init__.py
+++ b/coffee/visitors/__init__.py
@@ -1,2 +1,3 @@
 from __future__ import absolute_import
 from coffee.visitors.utilities import *
+from coffee.visitors.inspectors import *

--- a/coffee/visitors/__init__.py
+++ b/coffee/visitors/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import absolute_import
+from coffee.visitors.utilities import *

--- a/coffee/visitors/inspectors.py
+++ b/coffee/visitors/inspectors.py
@@ -1,0 +1,540 @@
+from __future__ import absolute_import
+from coffee.visitor import Visitor, Environment
+from coffee.base import READ, WRITE, LOCAL, EXTERNAL, Symbol
+from collections import defaultdict, OrderedDict, Counter
+import itertools
+
+__all__ = ["FindInnerLoops", "CheckPerfectLoop",
+           "CountOccurences", "DetermineUnrollFactors",
+           "MaxLoopDepth", "FindLoopNests",
+           "FindCoffeeExpressions", "SymbolReferences",
+           "SymbolDependencies", "SymbolModes",
+           "SymbolDeclarations", "FindInstances"]
+
+
+class FindInnerLoops(Visitor):
+
+    """Find all inner-most loops in an AST.
+
+    Returns a list of the inner-most :class:`.For` loops or an empty
+    list if none were found."""
+
+    def visit_object(self, o, env):
+        return []
+
+    def visit_Node(self, o, env, *args, **kwargs):
+        # Concatenate transformed children
+        return list(itertools.chain(*args))
+
+    def visit_For(self, o, env):
+        # Check for loops in children
+        children = self.visit(o.children[0], env=env)
+        if children:
+            # Yes, return those
+            return children
+        # No return ourselves
+        return [o]
+
+
+class CheckPerfectLoop(Visitor):
+
+    """
+    Check if a Node is a perfect loop nest.
+    """
+
+    def visit_object(self, o, env):
+        # Unhandled, return False to be safe.
+        return False
+
+    def visit_Perfect(self, o, env):
+        # Perfect nodes are in a perfect loop if they're in a loop.
+        try:
+            return env["in_loop"]
+        except KeyError:
+            return False
+
+    def visit_For(self, o, env):
+        if env["in_loop"] and env["multiple_statements"]:
+            return False
+        new_env = Environment(env, in_loop=True)
+        return self.visit(o.children[0], env=new_env)
+
+    def visit_Block(self, o, env):
+        # Does this block contain multiple statements?
+        multi = env["multiple_statements"] or len(o.children) > 1
+        new_env = Environment(env, multiple_statements=multi)
+        return env["in_loop"] and all(self.visit(op, env=new_env) for op in o.children)
+
+
+class CountOccurences(Visitor):
+
+    """Count all occurances of :class:`~.Symbol`\s in an AST.
+
+    :arg key: a comparison key for the symbols.
+    :arg only_rvalues: optionally only count rvalues in statements.
+
+    Returns a dict mapping symbol keys to number of occurrences.
+    """
+    def __init__(self, key=lambda x: (x.symbol, x.rank), only_rvalues=False):
+        self.key = key
+        self.rvalues = only_rvalues
+        super(CountOccurences, self).__init__()
+
+    def visit_object(self, o, env):
+        # Not a symbol, return identity for summation
+        return {}
+
+    def visit_list(self, o, env):
+        # Walk list entries (since some operands methods return lists)
+        ret = Counter()
+        for entry in o:
+            ret.update(self.visit(entry, env=env))
+        return ret
+
+    def visit_Node(self, o, env, *args, **kwargs):
+        # Walk the transformed children and sum up.
+        ret = Counter()
+        for d in args:
+            ret.update(d)
+        return ret
+
+    def visit_Assign(self, o, env):
+        ret = Counter()
+        if self.rvalues:
+            # Only counting rvalues, so don't walk lvalue
+            ops = o.children[1:]
+        else:
+            ops = o.children
+        args = [self.visit(op, env=env) for op in ops]
+        for d in args:
+            ret.update(d)
+        return ret
+
+    visit_Incr = visit_Assign
+
+    visit_Decr = visit_Assign
+
+    def visit_Symbol(self, o, env):
+        return {self.key(o): 1}
+
+
+class DetermineUnrollFactors(Visitor):
+    """
+    Determine unroll factors for all For loops in a tree.
+
+    Returns a dict mapping iteration variable names to possible unroll
+    factors for that iteration variable.
+
+    Innermost loops always get an unroll factor of 1, to give the
+    backend compiler a chance of auto-vectorizing them.  Outer loops
+    are given potential unroll factors that result in no loop
+    remainders.
+    """
+    def visit_object(self, o, env):
+        return {}
+
+    def visit_Node(self, o, env, *args, **kwargs):
+        ret = {}
+        for a in args:
+            ret.update(a)
+        return ret
+
+    def visit_For(self, o, env):
+        ret = self.visit(o.children[0], env=env)
+        if len(ret) is 0:
+            # No child for loops
+            # Inner loops are not unrollable
+            ret[o.dim] = (1, )
+            return ret
+        # Not an inner loop, determine unroll factors
+        ret[o.dim] = tuple(i for i in range(1, o.size+1) if (o.size % i) == 0)
+        return ret
+
+
+class MaxLoopDepth(Visitor):
+
+    """Return the maximum loop depth in the tree."""
+
+    def visit_object(self, o, env):
+        return 0
+
+    def visit_Node(self, o, env, *args, **kwargs):
+        if len(args) == 0:
+            return 0
+        return max(args)
+
+    def visit_For(self, o, env, *args, **kwargs):
+        return 1 + max(args)
+
+
+class FindLoopNests(Visitor):
+
+    """Return a list of lists of loop nests in the tree.
+
+    Each list entry describes a loop nest with the outer-most loop
+    first.  Each entry therein is a tuple (loop_node, node_parent).
+
+    By default the top-level call to visit will record a node_parent
+    of None for the visited Node.  To provide one, pass an
+    environment in to the visitor::
+
+    .. code-block::
+
+       v.visit(node, {"node_parent": parent})
+
+    """
+
+    def visit_object(self, o, env):
+        return []
+
+    def visit_Node(self, o, env):
+        ops, _ = o.operands()
+        new_env = Environment(env, node_parent=o)
+        # Visit children recording this node as the parent
+        return list(itertools.chain(*[self.visit(op, env=new_env) for op in ops]))
+
+    def visit_For(self, o, env):
+        # Transform operands using generic visit_Node
+        args = self.visit_Node(o, env)
+        # Cons (node, node_parent) onto front of current loop-nest list
+        try:
+            parent = env["node_parent"]
+        except KeyError:
+            parent = None
+        me = (o, parent)
+        if len(args) == 0:
+            # Bottom of the nest, just return self
+            return ([me], )
+        # Transform child [a, b] into [(me, a), (me, b)]
+        return [list(itertools.chain((me, ), a)) for a in args]
+
+
+class FindCoffeeExpressions(Visitor):
+
+    """
+    Search the tree for :class:`~.Perfect` statements annotated with
+    :data:`"#pragma coffee expression"`.  Return a dict mapping the
+    annotated node to a tuple of (node_parent, containing_loop_nest,
+    index_access).
+
+    By default the top-level call to visit will record a node_parent
+    of None for the visited Node.  To provide one, pass an
+    environment in to the visitor::
+
+    .. code-block::
+
+       v.visit(node, {"node_parent": parent})
+
+    """
+
+    def visit_object(self, o, env):
+        return {}
+
+    def visit_Node(self, o, env):
+        ops, _ = o.operands()
+        new_env = Environment(env, node_parent=o)
+        args = [self.visit(op, env=new_env) for op in ops]
+        ret = OrderedDict()
+        # Merge values from children
+        for a in args:
+            ret.update(a)
+        return ret
+
+    def visit_Perfect(self, o, env):
+        for p in o.pragma:
+            opts = p.split(" ", 2)
+            # Don't care if we don't have three values
+            if len(opts) < 3:
+                continue
+            if opts[1] == "coffee" and opts[2] == "expression":
+                # (parent, loop-nest, rank)
+                try:
+                    parent = env["node_parent"]
+                except KeyError:
+                    parent = None
+                return {o: (parent, None, o.children[0].rank)}
+        return {}
+
+    def visit_For(self, o, env):
+        args = self.visit_Node(o, env)
+        # Nothing inside this for loop was annotated (we didn't see a
+        # Perfect node with #pragma coffee expression)
+        if len(args) == 0:
+            return {}
+        ret = OrderedDict()
+        try:
+            parent = env["node_parent"]
+        except KeyError:
+            parent = None
+        me = (o, parent)
+        for k, v in args.iteritems():
+            p, nest, rank = v
+            if nest is None:
+                # Statement is directly underneath this loop, so the
+                # loop nest structure is just the current loop
+                nest = (me, )
+            else:
+                # Inside a nested set of loops, so prepend current
+                # loop info to nest structure
+                nest = list(itertools.chain((me, ), nest))
+            # Merge with updated nest info
+            ret[k] = (p, nest, rank)
+        return ret
+
+
+class SymbolReferences(Visitor):
+
+    """
+    Visit the tree and return a dict mapping symbol names to tuples of
+    (node, node_parent) that reference the symbol with that name.
+    The node is the Symbol node with said name, the node_parent is the
+    parent of that node.
+
+    By default the top-level call to visit will record a node_parent
+    of None for the visited Node.  To provide one, pass an
+    environment in to the visitor::
+
+    .. code-block::
+
+       v.visit(node, {"node_parent": parent})
+
+    """
+
+    def visit_Symbol(self, o, env):
+        # Map name to (node, parent) tuple
+        try:
+            parent = env["node_parent"]
+        except KeyError:
+            parent = None
+        return {o.symbol: [(o, parent)]}
+
+    def visit_object(self, o, env):
+        # Identity
+        return {}
+
+    def visit_list(self, o, env):
+        ret = defaultdict(list)
+        for entry in o:
+            a = self.visit(entry, env=env)
+            for k, v in a.iteritems():
+                ret[k].extend(v)
+        return ret
+
+    def visit_Node(self, o, env):
+        ops, _ = o.operands()
+        new_env = Environment(env, node_parent=o)
+        args = [self.visit(op, env=new_env) for op in ops]
+        ret = defaultdict(list)
+        # Merge dicts
+        for a in args:
+            for k, v in a.iteritems():
+                ret[k].extend(v)
+        return ret
+
+
+class SymbolDependencies(Visitor):
+
+    """
+    Visit the tree and return a dict collecting symbol dependencies.
+
+    The returned dict contains both maps from nodes to a (possibly
+    empty) loop list the symbol depends on, and maps symbol names to
+    WRITE access.
+    """
+
+    def visit_Symbol(self, o, env):
+        # Empty loop nest for starters
+        return {o: []}
+
+    def visit_object(self, o, env):
+        return {}
+
+    def visit_Node(self, o, env):
+        ops, _ = o.operands()
+        args = [self.visit(op, env=env) for op in ops]
+        ret = OrderedDict()
+        # Merge values from children
+        for a in args:
+            ret.update(a)
+        return ret
+
+    visit_EmptyStatement = visit_object
+
+    def visit_Decl(self, o, env):
+        # Declaration init could have symbol access
+        args = [self.visit(op, env=env) for op in [o.sym, o.init]]
+        ret = OrderedDict()
+        for a in args:
+            ret.update(a)
+        return ret
+
+    # Don't treat funcalls like perfect, but rather nodes
+    visit_FunCall = visit_Node
+
+    def visit_Perfect(self, o, env):
+        ret = OrderedDict()
+        lvalue = self.visit(o.children[0], env=env)
+        for k, v in lvalue.iteritems():
+            ret[k] = v
+            # lvalue name is WRITTEN
+            ret[k.symbol] = WRITE
+        for r in o.children[1:]:
+            d = self.visit(r, env=env)
+            ret.update(d)
+        return ret
+
+    def visit_For(self, o, env):
+        # Don't care about symbol access in increments, only children
+        args = [self.visit(op, env=env) for op in o.children]
+        ret = OrderedDict()
+        # First merge args
+        for a in args:
+            ret.update(a)
+        # Now fill in symbol loop dependencies.  If the symbol name is
+        # WRITTEN anywhere, then it's dependent on all loops in the
+        # current nest, otherwise only the ones that access it.
+        for k, v in ret.iteritems():
+            if type(k) is not Symbol:
+                # name, don't care about it here.
+                continue
+            mode = ret.get(k.symbol, READ)
+            if (mode == WRITE) or (o.dim in k.rank):
+                ret[k] = [o] + v
+        return ret
+
+
+class SymbolModes(Visitor):
+
+    """
+    Visit the tree and return a dict mapping Symbols to tuples of
+    (access mode, parent class).
+
+    :class:`~.Symbol`\s are accessed as READ-only unless they appear
+    as lvalues in a :class:`~.Perfect` statement.
+
+    By default the top-level call to visit will record a parent class
+    of NoneType for Symbols without a parent.  To pass in a parent by
+    hand, provide an environment to the visitor.
+
+    .. code-block::
+
+       v.visit(symbol, {"node_parent": parent})
+
+    """
+    def visit_object(self, o, env):
+        return {}
+
+    def visit_Node(self, o, env):
+        new_env = Environment(env, node_parent=o)
+        ret = OrderedDict()
+        ops, _ = o.operands()
+        for op in ops:
+            # WARNING, if the same Symbol object appears multiple
+            # times, the "last" access wins, rather than WRITE winning.
+            # This assumes all nodes in the tree are unique instances
+            ret.update(self.visit(op, env=new_env))
+        return ret
+
+    def visit_Symbol(self, o, env):
+        try:
+            mode = env["access_mode"]
+        except KeyError:
+            mode = READ
+        try:
+            parent = env["node_parent"]
+        except KeyError:
+            parent = None
+        return {o: (mode, parent.__class__)}
+
+    # Don't do anything with declarations.  If you want lvalues to get
+    # a WRITE unless uninitialised, then custom visitor must be
+    # written.
+    visit_Decl = visit_object
+
+    def visit_Perfect(self, o, env):
+        new_env = Environment(env, node_parent=o)
+        write_env = Environment(new_env, access_mode=WRITE)
+        ret = OrderedDict()
+        # lvalues have access mode WRITE
+        ret.update(self.visit(o.children[0], env=write_env))
+        # All others have access mode READ
+        for op in o.children[1:]:
+            ret.update(self.visit(op, env=new_env))
+        return ret
+
+
+class SymbolDeclarations(Visitor):
+
+    """Return a dict mapping symbol names to a tuple of the declaring
+    node.  The node is annotated in place with information about
+    whether it is a LOCAL declaration or EXTERNAL (via a function
+    argument).
+    """
+    def visit_object(self, o, env):
+        return {}
+
+    def visit_Node(self, o, env, *args, **kwargs):
+        ret = OrderedDict()
+        for a in args:
+            # WARNING, last sight of symbol wins.
+            ret.update(a)
+        return ret
+
+    def visit_FunDecl(self, o, env):
+        new_env = Environment(env, scope=EXTERNAL)
+        ret = OrderedDict()
+        for op in o.args:
+            ret.update(self.visit(op, env=new_env))
+        return ret
+
+    def visit_Decl(self, o, env):
+        # FIXME: be side-effect free
+        try:
+            o.scope = env["scope"]
+        except KeyError:
+            o.scope = LOCAL
+        return {o.sym.symbol: o}
+
+
+class FindInstances(Visitor):
+
+    """
+    Visit the tree and return a dict mapping types to a list of
+    instances of that type in the tree.
+
+    :arg types: list of types or single type to search for in the
+          tree.
+    :arg stop_when_found: optional, don't traverse the children of
+          matching types.
+    """
+
+    def __init__(self, types, stop_when_found=False):
+        self.types = types
+        self.stop_when_found = stop_when_found
+        super(FindInstances, self).__init__()
+
+    def visit_object(self, o, env):
+        return {}
+
+    def visit_list(self, o, env):
+        ret = defaultdict(list)
+        for entry in o:
+            a = self.visit(entry, env=env)
+            for k, v in a.iteritems():
+                ret[k].extend(v)
+        return ret
+
+    def visit_Node(self, o, env):
+        ret = defaultdict(list)
+        if isinstance(o, self.types):
+            ret[type(o)].append(o)
+            # Don't traverse children if stop-on-found
+            if self.stop_when_found:
+                return ret
+        # Not found, or traversing children anyway
+        ops, _ = o.operands()
+        for op in ops:
+            a = self.visit(op, env=env)
+            for k, v in a.iteritems():
+                ret[k].extend(v)
+        return ret

--- a/coffee/visitors/utilities.py
+++ b/coffee/visitors/utilities.py
@@ -1,0 +1,80 @@
+from __future__ import absolute_import
+from coffee.visitor import Visitor
+from copy import deepcopy
+
+
+__all__ = ["ReplaceSymbols", "CheckUniqueness", "Uniquify"]
+
+
+class ReplaceSymbols(Visitor):
+
+    """Replace named symbols in a tree, returning a new tree.
+
+    :arg syms: A dict mapping symbol names to new Symbol objects.
+    :arg key: a callable to generate a key from a Symbol, defaults to
+         the string representation.
+    :arg copy_result: optionally copy the new Symbol whenever it is
+         used (guaranteeing that it will be unique)"""
+    def __init__(self, syms, key=lambda x: str(x),
+                 copy_result=False):
+        self.syms = syms
+        self.key = key
+        self.copy_result = copy_result
+        super(ReplaceSymbols, self).__init__()
+
+    def visit_Symbol(self, o, env):
+        try:
+            ret = self.syms[self.key(o)]
+            if self.copy_result:
+                ops, kwargs = ret.operands()
+                ret = ret.reconstruct(ops, **kwargs)
+            return ret
+        except KeyError:
+            return o
+
+    def visit_object(self, o, env):
+        return o
+
+    visit_Node = Visitor.maybe_reconstruct
+
+
+class CheckUniqueness(Visitor):
+
+    """
+    Check if all nodes in a tree are unique instances.
+    """
+    def visit_object(self, o, env):
+        return set()
+
+    # Some lists appear in operands()
+    def visit_list(self, o, env):
+        ret = set()
+        # Walk list entrys
+        for entry in o:
+            a = self.visit(entry, env=env)
+            if len(ret.intersection(a)) != 0:
+                raise RuntimeError("Tree does not contain unique nodes")
+            ret.update(a)
+        return ret
+
+    def visit_Node(self, o, env, *args, **kwargs):
+        ret = set([o])
+        for a in args:
+            if len(ret.intersection(a)) != 0:
+                raise RuntimeError("Tree does not contain unique nodes")
+            ret.update(a)
+        return ret
+
+
+class Uniquify(Visitor):
+    """
+    Uniquify all nodes in a tree by recursively calling reconstruct
+    """
+
+    visit_Node = Visitor.always_reconstruct
+
+    def visit_object(self, o, env):
+        return deepcopy(o)
+
+    def visit_list(self, o, env):
+        return [self.visit(e, env=env) for e in o]

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,0 +1,48 @@
+import pytest
+from coffee.visitor import Environment
+
+
+@pytest.fixture
+def env():
+    return Environment({}, foo=1)
+
+
+@pytest.fixture
+def child(env):
+    return Environment(env, bar=2)
+
+@pytest.fixture
+def shadow(env):
+    return Environment(env, foo=2)
+
+
+def test_lookup_key(env):
+    assert env["foo"] == 1
+
+
+def test_missing_key(env):
+    with pytest.raises(KeyError):
+        env["bar"]
+
+
+def test_child_sees_parent(child):
+    assert child["foo"] == 1
+    assert child["bar"] == 2
+
+
+def test_child_shadows_parent(shadow):
+    assert shadow["foo"] == 2
+
+
+def test_repr(child):
+    new_env = eval(repr(child))
+
+    assert child["foo"] == 1
+    assert child["bar"] == 2
+    assert new_env["foo"] == 1
+    assert new_env["bar"] == 2
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,0 +1,129 @@
+import pytest
+from coffee.base import *
+from coffee.visitors import *
+from collections import Counter
+
+
+@pytest.mark.parametrize("key",
+                         [lambda x: x.symbol,
+                          lambda x: x,
+                          lambda x: x.symbol == "a"],
+                         ids=["symbol_name", "symbol_identity",
+                              "symbol_name_is_a"])
+@pytest.mark.parametrize("symbols",
+                         ["a",
+                          "a,a",
+                          "a,a,b",
+                          "b"])
+def test_count_occurences_block(key, symbols):
+    v = CountOccurences(key=key)
+
+    symbols = [Symbol(a) for a in symbols.split(",")]
+    tree = Block(symbols)
+
+    expect = Counter()
+    for sym in symbols:
+        expect[key(sym)] += 1
+
+    assert v.visit(tree) == expect
+
+
+@pytest.mark.parametrize("key",
+                         [lambda x: x.symbol,
+                          lambda x: x,
+                          lambda x: x.symbol == "a"],
+                         ids=["symbol_name", "symbol_identity",
+                              "symbol_name_is_a"])
+@pytest.mark.parametrize("only_rvalues",
+                         [False, True],
+                         ids=["all_children", "only_rvalues"])
+@pytest.mark.parametrize("lvalue",
+                         ["a", "b", "c"])
+@pytest.mark.parametrize("rvalue",
+                         ["a,a",
+                          "a,b,c",
+                          "c",
+                          "b",
+                          "d"])
+def test_count_occurences_assign(key, only_rvalues,
+                                 lvalue, rvalue):
+    v = CountOccurences(key=key, only_rvalues=only_rvalues)
+
+    rvalue = [Symbol(a) for a in rvalue.split(",")]
+
+    lvalue = Symbol(lvalue)
+
+    expect = Counter()
+
+    if not only_rvalues:
+        expect[key(lvalue)] += 1
+
+    for sym in rvalue:
+        expect[key(sym)] += 1
+
+    rvalue = reduce(Prod, rvalue)
+
+    tree = Assign(lvalue, rvalue)
+
+    assert v.visit(tree) == expect
+
+
+@pytest.mark.parametrize("structure",
+                         ([],
+                          [[]],
+                          [None, []],
+                          [None, [[], []]],
+                          [None, [[None, [], [[]]]]]))
+def test_find_inner_loops(structure):
+    v = FindInnerLoops()
+
+    inner_loops = []
+    def build_loop(structure):
+        ret = []
+        for entry in structure:
+            if entry is None:
+                continue
+            else:
+                loop = Block([build_loop(entry)])
+                ret.append(loop)
+        loop = For(Symbol("a"), Symbol("b"), Symbol("c"),
+                   Block(ret, open_scope=True))
+        if ret == []:
+            inner_loops.append(loop)
+        return loop
+
+    loop = build_loop(structure)
+
+    expect = sorted(inner_loops)
+
+    loops = v.visit(loop)
+
+    assert sorted(loops) == expect
+
+
+def test_check_perfect_loop():
+    v = CheckPerfectLoop()
+
+    a = Symbol("a")
+    b = Symbol("b")
+    loop = c_for("i", 10, [Assign(a, b)]).children[0]
+
+    env = dict(in_loop=True, multiple_statements=False)
+    assert v.visit(loop, env=env)
+
+    loop2 = c_for("j", 10, [loop]).children[0]
+
+    assert v.visit(loop2, env=env)
+
+    loop3 = c_for("k", 10, [loop2, Assign(b, a)]).children[0]
+
+    assert not v.visit(loop3, env=env)
+
+    loop4 = c_for("k", 10, [Assign(a, b), Assign(b, a)]).children[0]
+
+    assert v.visit(loop4, env=env)
+
+
+if __name__ == "__main__":
+    import os
+    pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Add tree visitor infrastructure to COFFEE and migrate current tree inspectors to new visitors.

New visitors can be created by subclassing coffee.visitor.Visitor (which see), which comes with a number of built-in "default" methods for reusing or reconstructing nodes.

Some utility visitors (for replacing symbols matching a name or checking for uniqueness of nodes in a tree) are in coffee.visitors.utilities.

Tree inspectors are in coffee.visitors.inspectors.

Additionally, this change adds `operands` and `reconstruct` methods to all base ast nodes.  This is an endeavour to allow for tree transformations without modification in place.  Note that there may be corner cases that are not handled correctly.

Code gen should be migrated to this new infrastructure but is not yet done.