### PR TITLE
Add conda recipe and binstar-build file

### DIFF
--- a/.binstar.yml
+++ b/.binstar.yml
@@ -1,0 +1,13 @@
+package: coffee
+user: firedrakeproject
+
+platform:
+  - linux-64
+
+engine:
+  - python=2.7
+
+script:
+  - conda build -q condarecipe
+
+build_targets: conda

--- a/condarecipe/build.sh
+++ b/condarecipe/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/condarecipe/meta.yaml
+++ b/condarecipe/meta.yaml
@@ -1,9 +1,12 @@
 package:
   name: coffee
-  version: 0.1.0
+  version: {{ environ.get('GIT_DESCRIBE_TAG','') }}
 
 source:
   path: ..
+
+build:
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
 
 requirements:
   build:

--- a/condarecipe/meta.yaml
+++ b/condarecipe/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: coffee
+  version: 0.1.0
+
+source:
+  path: ..
+
+requirements:
+  build:
+    - python
+    - networkx
+
+  run:
+    - python
+    - numpy
+    - networkx
+
+test:
+  requires:
+    - pytest
+    - flake8
+  commands:
+    - py.test {{ os.path.join(environ.get('SRC_DIR'), 'tests') }} -v
+    - flake8 {{ environ.get('SRC_DIR') }}
+
+about:
+  home: http://www.firedrakeproject.org
+  license: BSD 3-clause
+  summary: COFFEE - COmpiler For Fast Expression Evaluation


### PR DESCRIPTION
The conda recipe enables building of conda packages, which can be done on a local machine or on Binstar. The testing regime is inspired by the existing .travis.yml - conda will run the tests on the package before declaring success.

The second part of this PR is the binstar-build file, which executes the conda build on a binstar worker, and then uploads the generated package to the firedrakeproject's channel - this can be installed by a conda user who runs `conda install -c firedrakeproject coffee`. (It is also possible to add firedrakeproject to their default conda channels so that the `-c firedrakeproject` argument is unnecessary - that is down to the user's choice).

I'm not sure I've done the right thing for the version number here, as I'm not sure what the convention for it should be for coffee. One common thing to do for packages that are builds of a development branch and not a release is to use the tag from git describe as the version number, then use the number of commits since that tag for the build number - this guarantees that the package name is monotonically increasing for each subsequent revision of the package, and therefore conda will always be able to find the latest build. I couldn't do this here because there are no tags, but if a tag were added I could update this PR to use that method. If another version/build number scheme is preferable, please let me know and I'll update the PR to use it.