### PR TITLE
Rework the optimization engine (Add O4)

### DIFF
--- a/coffee/ast_analyzer.py
+++ b/coffee/ast_analyzer.py
@@ -185,3 +185,20 @@ class ExpressionGraph(object):
             elif nx.has_path(self.deps, s.symbol, target_sym.symbol):
                 return True
         return False
+
+    def shares(self, symbols):
+        """Return an iterator of tuples, each tuple being a group of symbols
+        identifiers sharing the same reads."""
+        groups = set()
+        for i in [set(self.reads(s)) for s in symbols]:
+            group = tuple(j for j in symbols if i.intersection(set(self.reads(j))))
+            groups.add(group)
+        return list(groups)
+
+    def readers(self, sym):
+        """Return the list of symbol identifiers that read from ``sym``."""
+        return [i for i, j in self.deps.in_edges(sym)]
+
+    def reads(self, sym):
+        """Return the list of symbol identifiers that ``sym`` reads from."""
+        return [j for i, j in self.deps.out_edges(sym)]

--- a/coffee/ast_analyzer.py
+++ b/coffee/ast_analyzer.py
@@ -121,11 +121,11 @@ class StmtTracker(OrderedDict):
 
     @property
     def all_stmts(self):
-        return set((stmt_info.stmt for stmt_info in self.values()))
+        return set((stmt_info.stmt for stmt_info in self.values() if stmt_info.stmt))
 
     @property
     def all_places(self):
-        return set((stmt_info.place for stmt_info in self.values()))
+        return set((stmt_info.place for stmt_info in self.values() if stmt_info.place))
 
     @property
     def all_loops(self):

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -647,9 +647,13 @@ class Decl(Statement):
         self.qual = qualifiers or []
         self.attr = attributes or []
         self.init = as_symbol(init) if init is not None else EmptyStatement()
+        self._core = self.sym.rank
 
     def operands(self):
         return [self.typ, self.sym, self.init, self.qual, self.attr], {}
+
+    def pad(self, rank):
+        self.sym.rank = rank
 
     @property
     def lvalue(self):
@@ -673,6 +677,15 @@ class Decl(Statement):
           -> ``(20, 10)``)
         """
         return self.sym.rank or (0,)
+
+    @property
+    def core(self):
+        """Return the size of the declaraed variable without including padding."""
+        return self._core
+
+    @core.setter
+    def core(self, val):
+        self._core = val
 
     @property
     def is_const(self):

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -1180,11 +1180,15 @@ IDIV = Access("IDIV")
 
 class Scope(object):
 
-    """An ``EXTERNAL`` scope means the /Decl/ is an argument of a kernel (i.e.,
-    when it appears in the list of declarations of a /FunDecl/ object). Otherwise,
-    a ``LOCAL`` scope indicates the /Decl/ is within the body of a kernel."""
+    """Three /Scope/s are possible:
 
-    _scopes = ["LOCAL", "EXTERNAL"]
+        * ``EXTERNAL``: the /Decl/ is a kernel argument
+        * ``LOCAL``: the /Decl/ lives within the kernel body
+        * ``BUFFER``: the /Decl/ is ``LOCAL``, but it is special in that it maps
+            data from an ``EXTERNAL`` /Decl/
+    """
+
+    _scopes = ["LOCAL", "EXTERNAL", "BUFFER"]
 
     def __init__(self, scope):
         if scope not in Scope._scopes:
@@ -1196,3 +1200,4 @@ class Scope(object):
 
 LOCAL = Scope("LOCAL")
 EXTERNAL = Scope("EXTERNAL")
+BUFFER = Scope("BUFFER")

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -449,6 +449,11 @@ class Symbol(Expr):
     def dim(self):
         return len(self.rank)
 
+    @property
+    def is_const(self):
+        from utils import is_const_dim
+        return all(is_const_dim(r) for r in self.rank)
+
     def gencode(self, not_scope=True, parent=None):
         points = ""
         if not self.offset:

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -827,10 +827,11 @@ class For(Statement):
         self.children[0].children = new_body
 
     def gencode(self, not_scope=False):
-        return "\n".join(self.pragma) + "\n" + for_loop(self.init.gencode(True),
-                                                        self.cond.gencode(),
-                                                        self.incr.gencode(True),
-                                                        self.children[0].gencode())
+        pragma = [i for i in self.pragma if 'coffee' not in i]
+        return "\n".join(pragma) + "\n" + for_loop(self.init.gencode(True),
+                                                   self.cond.gencode(),
+                                                   self.incr.gencode(True),
+                                                   self.children[0].gencode())
 
 
 class Switch(Statement):

--- a/coffee/expression.py
+++ b/coffee/expression.py
@@ -64,7 +64,7 @@ class MetaExpr(object):
 
     @property
     def dims(self):
-        return [l.dim for l in self.loops]
+        return tuple(l.dim for l in self.loops)
 
     @property
     def domain_dims(self):
@@ -72,7 +72,7 @@ class MetaExpr(object):
 
     @property
     def out_domain_dims(self):
-        return [d for d in self.dims if d not in self.domain_dims]
+        return tuple(d for d in self.dims if d not in self.domain_dims)
 
     @property
     def loops(self):

--- a/coffee/expression.py
+++ b/coffee/expression.py
@@ -39,7 +39,7 @@ class MetaExpr(object):
 
     """Metadata container for a compute-intensive expression."""
 
-    def __init__(self, type, parent, loops_info, domain):
+    def __init__(self, type, parent, loops_info, domain, mode=0):
         """Initialize the MetaExpr.
 
         :param type: the C type of the expression.
@@ -50,11 +50,13 @@ class MetaExpr(object):
              evaluated by the expression. The i-th entry corresponds to
              the loop dimension along which iteration occurs (For example,
              given an output tensor ``A[i][j]``, ``domain=(i, j)``).
+        :param mode: suggested rewrite mode.
         """
         self._type = type
         self._parent = parent
         self._loops_info = list(loops_info)
         self._domain = domain
+        self._mode = mode
 
     @property
     def type(self):
@@ -141,19 +143,29 @@ class MetaExpr(object):
     def is_tensor(self):
         return not self.is_scalar
 
+    @property
+    def mode(self):
+        return self._mode
+
+    @mode.setter
+    def mode(self, value):
+        self._mode = value
+
 
 def copy_metaexpr(expr_info, **kwargs):
     """Given a ``MetaExpr``, return a plain new ``MetaExpr`` starting from a
     copy of ``expr_info``, and replaces some attributes as specified in
     ``kwargs``. In particular, ``kwargs`` has the following keys:
 
-    * ``parent``: the block node that embeds the expression.
-    * ``loops_info``: an iterator of 2-tuple ``(loop, loop_parent)`` which
-      substitute analogous information in the new ``MetaExpr``.
-    * ``domain``: the domain of the output tensor evaluated by the expression.
+        * parent: the block node that embeds the expression.
+        * loops_info: an iterator of 2-tuple ``(loop, loop_parent)`` which
+          substitute analogous information in the new ``MetaExpr``.
+        * domain: the domain of the output tensor evaluated by the expression.
+        * mode: the suggested rewrite mode.
     """
     parent = kwargs.get('parent', expr_info.parent)
     domain = kwargs.get('domain', expr_info.domain_dims)
+    mode = kwargs.get('mode', expr_info.mode)
 
     new_loops_info, old_loops_info = [], expr_info.loops_info
     to_replace_loops_info = kwargs.get('loops_info', [])
@@ -166,4 +178,4 @@ def copy_metaexpr(expr_info, **kwargs):
         else:
             new_loops_info.append(loop_info)
 
-    return MetaExpr(expr_info.type, parent, new_loops_info, domain)
+    return MetaExpr(expr_info.type, parent, new_loops_info, domain, mode)

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -454,7 +454,7 @@ class ExpressionFissioner(LoopScheduler):
         :arg stmt: the expression to be fissioned
         :arg expr_info: ``MetaExpr`` object describing ``stmt``
         """
-        exprs = {}
+        exprs = OrderedDict()
         splittable = (stmt, expr_info)
         while splittable:
             split, splittable = self.cutter.cut(*splittable)

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -653,9 +653,6 @@ class ZeroRemover(LoopScheduler):
         A dictionary describing the structure of the new iteration spaces is
         returned.
         """
-
-        # 1) Identify the initial sparsity pattern of the symbols in /root/
-        nz_in_syms = {s: d.nonzero for s, d in self.decls.items() if d.nonzero}
         nz_info = OrderedDict()
 
         # 2) Track propagation of non-zero blocks by symbolic execution. This

--- a/coffee/loop_scheduler.py
+++ b/coffee/loop_scheduler.py
@@ -774,7 +774,7 @@ class ZeroRemover(LoopScheduler):
         return nz_syms, new_nz_info
 
     def _shrink(self, root, nz_syms, nz_info):
-        references = SymbolReferences().visit(root, env=SymbolReferences.default_env)
+        references = SymbolReferences().visit(root, ret=SymbolReferences.default_retval())
         dataspaces = defaultdict(list)
 
         # Calculate the dataspaces

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -430,7 +430,7 @@ class LoopOptimizer(object):
             # differently by injection
             if i_syms:
                 dissected = find_expression(expr, Prod, expr_info.domain_dims, i_syms)
-                leftover = find_expression(expr, Prod, expr_info.domain_dims, out_syms=i_syms)
+                leftover = find_expression(expr, dims=expr_info.domain_dims, out_syms=i_syms)
                 leftover = {(): list(flatten(leftover.values()))}
                 dissected = dict(dissected.items() + leftover.items())
             else:

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -33,7 +33,6 @@
 
 import operator
 import resource
-import sys
 from warnings import warn as warning
 from math import factorial as fact
 
@@ -354,9 +353,6 @@ class LoopOptimizer(object):
         which tries to pre-evaluate subexpressions whose values are known at
         code generation time. Injection is essential to factorize such subexprs.
         """
-
-        # 0) Injection may grow too much the AST, need allow deeper visits
-        sys.setrecursionlimit(4000)
 
         # 1) Find out and unroll injectable loops. For unrolling we create new
         # expressions; that is, for now, we do not modify the AST in place.

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -103,6 +103,10 @@ class LoopOptimizer(object):
         """
         ExpressionRewriter.reset()
 
+        # Set a rewrite mode for each expression
+        for stmt, expr_info in self.exprs.items():
+            expr_info.mode = mode
+
         # Passes preliminar to expression rewriting
         if mode == 3:
             self._inject()
@@ -121,21 +125,21 @@ class LoopOptimizer(object):
         for stmt, expr_info in self.exprs.items():
             ew = ExpressionRewriter(stmt, expr_info, self.decls, self.header,
                                     self.hoisted, self.expr_graph)
-            if expr_info.dimension in [0, 1] and mode in [1, 2]:
+            if expr_info.dimension in [0, 1] and expr_info.mode in [1, 2]:
                 ew.licm(hoist_out_domain=True)
                 continue
 
-            if mode == 1:
+            if expr_info.mode == 1:
                 ew.licm()
 
-            elif mode == 2:
+            elif expr_info.mode == 2:
                 ew.licm()
                 if expr_info.is_tensor:
                     ew.expand()
                     ew.factorize()
                     ew.licm()
 
-            elif mode == 3:
+            elif expr_info.mode == 3:
                 if expr_info.is_tensor:
                     ew.expand(mode='full')
                     ew.factorize(mode='immutable')

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -520,7 +520,7 @@ class CPULoopOptimizer(LoopOptimizer):
 
         unrolled_loops = set()
         for itspace, uf in loop_uf.items():
-            new_exprs = {}
+            new_exprs = OrderedDict()
             for stmt, expr_info in self.exprs.items():
                 loop = [l for l in expr_info.perfect_loops if l.dim == itspace]
                 if not loop:
@@ -571,7 +571,7 @@ class CPULoopOptimizer(LoopOptimizer):
                 A[i][j] += B[i]*X[j]
         """
 
-        new_exprs = {}
+        new_exprs = OrderedDict()
         elf = ExpressionFissioner(cut=cut, loops='expr')
         for stmt, expr_info in self.exprs.items():
             new_exprs.update(elf.fission(stmt, expr_info))

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -151,10 +151,10 @@ class LoopOptimizer(object):
                     ew.factorize(mode='immutable')
                     ew.licm(hoist_out_domain=True)
 
-            # Try merging and optimizing the loops created by rewriting
-            merged_loops = SSALoopMerger(ew.expr_graph).merge(self.header)
-            for merged, merged_in in merged_loops:
-                [self.hoisted.update_loop(l, merged_in) for l in merged]
+        # Try merging and optimizing the loops created by rewriting
+        merged_loops = SSALoopMerger(self.expr_graph).merge(self.header)
+        for merged, merged_in in merged_loops:
+            [self.hoisted.update_loop(l, merged_in) for l in merged]
 
         # Handle the effects, at the C-level, of the AST transformation
         self._recoil()

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -117,7 +117,7 @@ class LoopOptimizer(object):
             ew = ExpressionRewriter(stmt, expr_info, self.decls, self.header,
                                     self.hoisted, self.expr_graph)
             if expr_info.dimension in [0, 1] and expr_info.mode in [1, 2]:
-                ew.licm(hoist_out_domain=True)
+                ew.licm(only_outdomain=True)
                 continue
 
             if expr_info.mode == 1:
@@ -134,13 +134,13 @@ class LoopOptimizer(object):
                 if expr_info.is_tensor:
                     ew.expand(mode='full')
                     ew.factorize(mode='immutable')
-                    ew.licm(hoist_out_domain=True)
+                    ew.licm(only_const=True)
                     ew.factorize(mode='constants')
                     ew.reassociate()
-                    ew.licm(hoist_domain_const=True)
+                    ew.licm(only_domain=True)
                     ew.simplify()
                     ew.factorize(mode='immutable')
-                    ew.licm(hoist_out_domain=True)
+                    ew.licm(only_const=True)
 
         # Try merging and optimizing the loops created by rewriting
         merged_loops = SSALoopMerger(self.expr_graph).merge(self.header)
@@ -469,7 +469,7 @@ class LoopOptimizer(object):
                     ew.expand(mode='full')
                     ew.factorize(mode='immutable')
                     ew.factorize(mode='constants')
-                    nterms = ew.licm(look_ahead=True, hoist_domain_const=True)
+                    nterms = ew.licm(look_ahead=True, only_domain=True)
                     nterms = len(uniquify(nterms[expr_info.dims])) or 1
                     fake_parent[fake_parent.index(fake_stmt)] = stmt
                     cost = nterms * increase_factor

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -127,8 +127,8 @@ class LoopOptimizer(object):
                     ew.licm(only_outdomain=True)
                 elif expr_info.dimension == 1:
                     ew.licm(only_outdomain=True)
-                    ew.expand(mode='full')
-                    ew.factorize(mode='immutable')
+                    ew.expand(mode='domain')
+                    ew.factorize(mode='domain')
                     ew.licm(only_outdomain=True)
                 else:
                     ew.licm()
@@ -137,13 +137,13 @@ class LoopOptimizer(object):
                     ew.licm()
 
             elif expr_info.mode == 3:
-                ew.expand(mode='full')
-                ew.factorize(mode='immutable')
+                ew.expand(mode='all')
+                ew.factorize(mode='all')
                 ew.licm(only_const=True)
                 ew.factorize(mode='constants')
                 ew.licm(only_domain=True)
                 ew.preevaluate()
-                ew.factorize(mode='immutable')
+                ew.factorize(mode='domain')
                 ew.licm(only_const=True)
 
         # Try merging the loops created by expression rewriting
@@ -484,9 +484,7 @@ class LoopOptimizer(object):
                     fake_parent = expr_info.parent.children
                     fake_parent[fake_parent.index(stmt)] = fake_stmt
                     ew = ExpressionRewriter(fake_stmt, expr_info, self.decls)
-                    ew.expand(mode='full')
-                    ew.factorize(mode='immutable')
-                    ew.factorize(mode='constants')
+                    ew.expand(mode='all').factorize(mode='all').factorize(mode='domain')
                     nterms = ew.licm(look_ahead=True, only_domain=True)
                     nterms = len(uniquify(nterms[expr_info.dims])) or 1
                     fake_parent[fake_parent.index(fake_stmt)] = stmt

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -60,8 +60,8 @@ class LoopOptimizer(object):
         self.decls = decls
         self.exprs = exprs
 
-        # Track nonzero regions accessed in the loop nest
-        self.nz_info = {}
+        # Track nonzero regions accessed in each symbol
+        self.nz_syms = {}
         # Track data dependencies
         self.expr_graph = ExpressionGraph(header)
         # Track hoisted expressions
@@ -169,7 +169,7 @@ class LoopOptimizer(object):
 
         if any([d.nonzero for d in self.decls.values()]):
             zls = ZeroRemover(self.exprs, self.decls, self.hoisted)
-            self.nz_info = zls.reschedule(self.header)
+            self.nz_syms = zls.reschedule(self.header)
 
     def precompute(self, mode='perfect'):
         """Precompute statements out of ``self.loop``. This is achieved through

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -136,7 +136,7 @@ class LoopOptimizer(object):
                     ew.factorize()
                     ew.licm()
 
-            elif expr_info.mode == 'auto':
+            elif expr_info.mode == 3:
                 ew.expand(mode='full')
                 ew.factorize(mode='immutable')
                 ew.licm(only_const=True)
@@ -526,7 +526,7 @@ class LoopOptimizer(object):
             new_exprs = fissioner.fission(stmt, self.exprs.pop(stmt))
             self.exprs.update(new_exprs)
             for stmt, expr_info in new_exprs.items():
-                expr_info.mode = 'auto' if stmt in fissioner.matched else 2
+                expr_info.mode = 3 if stmt in fissioner.matched else 2
 
     def _recoil(self):
         """Increase the stack size if the kernel arrays exceed the stack limit

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -428,12 +428,16 @@ class LoopOptimizer(object):
 
             # Divide /expr/ into subexpressions, each subexpression affected
             # differently by injection
-            dissected = find_expression(expr, Prod, expr_info.domain_dims, i_syms)
+            if i_syms:
+                dissected = find_expression(expr, Prod, expr_info.domain_dims, i_syms)
+                leftover = find_expression(expr, Prod, expr_info.domain_dims, out_syms=i_syms)
+                leftover = {(): list(flatten(leftover.values()))}
+                dissected = dict(dissected.items() + leftover.items())
+            else:
+                dissected = {(): [expr]}
             if any(i not in flatten(dissected.keys()) for i in i_syms):
                 should_unroll = False
                 continue
-            if not dissected:
-                dissected[()] = [expr]
 
             # Apply the profitability model
             for i_syms, target_exprs in dissected.items():

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -563,10 +563,9 @@ class CPULoopOptimizer(LoopOptimizer):
         """
 
         new_exprs = {}
-        elf = ExpressionFissioner(cut)
+        elf = ExpressionFissioner(cut=cut, loops='expr')
         for stmt, expr_info in self.exprs.items():
-            # Split the expression
-            new_exprs.update(elf.fission(stmt, expr_info, True))
+            new_exprs.update(elf.fission(stmt, expr_info))
         self.exprs = new_exprs
 
     def blas(self, library):

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -159,8 +159,10 @@ class LoopOptimizer(object):
         # Handle the effects, at the C-level, of the AST transformation
         self._recoil()
 
-        # Reduce memory pressure by rearranging operations
+        # Reduce memory pressure by rearranging operations ...
         self._rearrange()
+        # ... which in turn requires updating the expression graph
+        self.expr_graph = ExpressionGraph(self.header)
 
     def eliminate_zeros(self):
         """Restructure the iteration spaces nested in this LoopOptimizer to

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -31,8 +31,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import operator
 import resource
 import sys
+from warnings import warn as warning
 
 from base import *
 from utils import *
@@ -318,7 +320,6 @@ class LoopOptimizer(object):
             # Clean up
             for stmt in to_remove:
                 innermost_block.children.remove(stmt)
-
 
     def _inject(self):
         """Unroll loops outside of the expressions iteration space into the

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -459,7 +459,8 @@ class LoopOptimizer(object):
                     # repetitions/ in the injected-values set. We consider
                     # combinations and not dispositions to take into account the
                     # (future) effect of factorization.
-                    projection = ProjectExpansion(i_syms).visit(target_expr)
+                    retval = ProjectExpansion.default_retval()
+                    projection = ProjectExpansion(i_syms).visit(target_expr, ret=retval)
                     projection = [i for i in projection if i]
                     increase_factor = 0
                     for i in projection:

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -138,7 +138,7 @@ class LoopOptimizer(object):
                     ew.factorize(mode='constants')
                     ew.reassociate()
                     ew.licm(only_domain=True)
-                    ew.simplify()
+                    ew.preevaluate()
                     ew.factorize(mode='immutable')
                     ew.licm(only_const=True)
 

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -163,6 +163,17 @@ class LoopOptimizer(object):
                     ew.factorize()
                     ew.licm()
 
+            elif expr_info.mode == 5:
+                ew.replacediv()
+                ew.expand(mode='all')
+                ew.factorize(mode='domain')
+                ew.licm(only_const=True)
+                ew.factorize(mode='domain')
+                ew.licm(only_const=True)
+                for i in range(1, expr_info.dimension):
+                    ew.factorize()
+                    ew.licm()
+
         # Try merging the loops created by expression rewriting
         merged_loops = SSALoopMerger(self.expr_graph).merge(self.header)
         # Update the trackers

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -397,17 +397,18 @@ class LoopOptimizer(object):
                 unrolled = False
                 continue
 
-            for i_syms, target_expr in to_inject.items():
-                # Is injection going to be profitable ?
-                # If the cost exceeds the potential save on flops, due to later
-                # optimizations potentially enabled by injection, skip
-                cost = reduce(operator.mul, [injectable[i][1] for i in i_syms])
-                save = [l.size for l in expr_info.out_domain_loops] or [0]
-                save = reduce(operator.mul, save)
-                if cost > save:
-                    unrolled = False
-                else:
-                    self.injected[stmt].append((target_expr, cost))
+            for i_syms, target_exprs in to_inject.items():
+                for target_expr in target_exprs:
+                    # Is injection going to be profitable ?
+                    # If the cost exceeds the potential save on flops, due to later
+                    # optimizations potentially enabled by injection, skip
+                    cost = reduce(operator.mul, [injectable[i][1] for i in i_syms])
+                    save = [l.size for l in expr_info.out_domain_loops] or [0]
+                    save = reduce(operator.mul, save)
+                    if cost > save:
+                        unrolled = False
+                    else:
+                        self.injected[stmt].append((target_expr, cost))
 
             # Finally, can perform the injection
             to_replace = {k: v[0] for k, v in injectable.items()}

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -481,10 +481,10 @@ class LoopOptimizer(object):
                     for i in projection:
                         partial = 1
                         for j in self.expr_graph.shares(i):
-                            # n=number of unique elements, k=group size
-                            n = injectable[j[0]][1]
-                            k = len(j)
-                            partial *= fact(n + k - 1)/(fact(k)*fact(n - 1))
+                            # _n=number of unique elements, _k=group size
+                            _n = injectable[j[0]][1]
+                            _k = len(j)
+                            partial *= fact(_n + _k - 1)/(fact(_k)*fact(_n - 1))
                         increase_factor += partial
                     increase_factor = increase_factor or 1
                     if increase_factor > save_factor:

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -149,6 +149,17 @@ class LoopOptimizer(object):
                 ew.factorize(mode='domain')
                 ew.licm(only_const=True)
 
+            elif expr_info.mode == 4:
+                ew.replacediv()
+                ew.licm(only_outdomain=True)
+                ew.expand(mode='domain')
+                ew.factorize(mode='domain')
+                ew.licm(only_outdomain=True)
+                ew.licm(only_const=True)
+                for i in range(1, expr_info.dimension):
+                    ew.factorize()
+                    ew.licm()
+
         # Try merging the loops created by expression rewriting
         merged_loops = SSALoopMerger(self.expr_graph).merge(self.header)
         # Update the trackers

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -362,7 +362,7 @@ class ASTKernel(object):
             }
         elif opts.get('O4'):
             params = {
-                'rewrite': 3,
+                'rewrite': 'auto',
                 'align_pad': True,
                 'dead_ops_elimination': True
             }

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -246,7 +246,7 @@ class ASTKernel(object):
                     loop_opt.unroll(dict(unroll))
 
                 # 5) Vectorization
-                if initialized and loop_opt.expr_domain_loops[0]:
+                if initialized and flatten(loop_opt.expr_domain_loops):
                     vect = LoopVectorizer(loop_opt)
                     if align_pad and not toblas:
                         # Padding and data alignment

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -219,8 +219,8 @@ class ASTKernel(object):
                 raise RuntimeError("SIMDization forbidden with zero-valued blocks avoidance")
             if unroll and v_type and v_type != VectStrategy.AUTO:
                 raise RuntimeError("SIMDization forbidden with unrolling")
-            if rewrite == 3 and len(info['exprs']) > 1:
-                warning("Rewrite mode=3 forbidden with multiple expressions")
+            if rewrite == 'auto' and len(info['exprs']) > 1:
+                warning("Rewrite mode=auto forbidden with multiple expressions")
                 warning("Switching to rewrite mode=2")
                 rewrite = 2
 

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -389,10 +389,7 @@ class ASTKernel(object):
         # each function (or "kernel") found in the provided AST
         for kernel in kernels:
             # Generate a specific code version
-            loop_opts = _generate_cpu_code(self, kernel, **params)
-
-            # Increase stack size if too much space is used on the stack
-            increase_stack(loop_opts)
+            _generate_cpu_code(self, kernel, **params)
 
             # Post processing of the AST ensures higher-quality code
             postprocess(kernel)

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -363,7 +363,8 @@ class ASTKernel(object):
         elif opts.get('O4'):
             params = {
                 'rewrite': 3,
-                'align_pad': True
+                'align_pad': True,
+                'dead_ops_elimination': True
             }
         elif opts.get('O3'):
             params = {

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -52,6 +52,7 @@ from collections import defaultdict, OrderedDict
 from warnings import warn as warning
 import itertools
 import operator
+import sys
 
 
 class ASTKernel(object):
@@ -405,11 +406,18 @@ def init_coffee(_isa, _compiler, _blas):
     """Initialize COFFEE."""
 
     global isa, compiler, blas, initialized
+
+    # Populate dictionaries with keywords for backend-specific (hardware,
+    # compiler, ...) optimizations
     isa = _init_isa(_isa)
     compiler = _init_compiler(_compiler)
     blas = _init_blas(_blas)
     if isa and compiler:
         initialized = True
+
+    # Allow visits of ASTs that become huge due to transformation. The constant
+    # /4000/ was empirically found to be an acceptable value
+    sys.setrecursionlimit(4000)
 
 
 def _init_isa(isa):

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -34,6 +34,7 @@
 """COFFEE's optimization plan constructor."""
 
 # The following global variables capture the internal state of COFFEE
+arch = {}
 compiler = {}
 isa = {}
 blas = {}
@@ -402,13 +403,14 @@ class ASTKernel(object):
         return self.ast.gencode()
 
 
-def init_coffee(_isa, _compiler, _blas):
+def init_coffee(_isa, _compiler, _blas, _arch='default'):
     """Initialize COFFEE."""
 
-    global isa, compiler, blas, initialized
+    global arch, isa, compiler, blas, initialized
 
     # Populate dictionaries with keywords for backend-specific (hardware,
     # compiler, ...) optimizations
+    arch = _init_arch(_arch)
     isa = _init_isa(_isa)
     compiler = _init_compiler(_compiler)
     blas = _init_blas(_blas)
@@ -418,6 +420,25 @@ def init_coffee(_isa, _compiler, _blas):
     # Allow visits of ASTs that become huge due to transformation. The constant
     # /4000/ was empirically found to be an acceptable value
     sys.setrecursionlimit(4000)
+
+
+def _init_arch(arch):
+    """Set architecture-specific parameters."""
+
+    # In the following, all sizes are in Bytes
+    if arch == 'default':
+        # The default architecture is a conventional multi-core CPU, such as
+        # an Intel Haswell
+        return {
+            'cache_size': 256 * 10**3,  # The private, closest memory to the core
+            'double': 8
+        }
+
+    else:
+        return {
+            'cache_size': 0,
+            'double': sys.maxint
+        }
 
 
 def _init_isa(isa):

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -49,6 +49,7 @@ from coffee.visitors import FindInstances
 
 from copy import deepcopy as dcopy
 from collections import defaultdict, OrderedDict
+from warnings import warn as warning
 import itertools
 import operator
 

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -341,8 +341,9 @@ class ExpressionRewriter(object):
             self.expr_info._loops_info.remove((l, p))
 
         # Precompute constant expressions
+        evaluator = Evaluate(self.decls, any(d.nonzero for s, d in self.decls.items()))
         for hoisted_loop in self.hoisted.all_loops:
-            evals = Evaluate(self.decls).visit(hoisted_loop, env=Evaluate.default_env)
+            evals = evaluator.visit(hoisted_loop, env=Evaluate.default_env)
             # First, find out identical tables
             mapper = defaultdict(list)
             for s, values in evals.items():

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -33,6 +33,7 @@
 
 from collections import defaultdict, OrderedDict, Counter
 from copy import deepcopy as dcopy
+from warnings import warn as warning
 import itertools
 
 from base import *

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -360,11 +360,14 @@ class ExpressionRewriter(object):
                 for s in symbols[1:]:
                     s_decl = self.hoisted[s.symbol].decl
                     self.header.children.remove(s_decl)
+                    self.hoisted.pop(s.symbol)
                     evals.pop(s)
-            # Finally, update declarations with precomputed values
+            # Finally, update the hoisted symbols
             for s, values in evals.items():
-                self.hoisted[s.symbol].decl.init = values
-                self.hoisted[s.symbol].decl.qual = ['static', 'const']
+                hoisted = self.hoisted[s.symbol]
+                hoisted.decl.init = values
+                hoisted.decl.qual = ['static', 'const']
+                self.hoisted.pop(s.symbol)
             # Clean up
             self.header.children.remove(hoisted_loop)
 

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -91,8 +91,8 @@ class ExpressionRewriter(object):
 
         For example, if a sub-expression ``E`` depends on ``[i, j]`` and the
         loop nest has three loops ``[i, j, k]``, then ``E`` is hoisted out from
-        the body of ``k`` to the body of ``i``). All hoisted expressions are
-        then wrapped and evaluated in a new loop in order to promote compiler
+        the body of ``k`` to the body of ``i``. All hoisted expressions are
+        then wrapped and evaluated in a 'clone' loop in order to promote compiler
         autovectorization.
 
         :param kwargs:
@@ -108,6 +108,9 @@ class ExpressionRewriter(object):
         """
         if kwargs.get('look_ahead'):
             return self.expr_hoister.extract(**kwargs)
+        elif kwargs.get('only_domain'):
+            # Reassociation can promote more hoisting in /only_domain/ mode
+            self.reassociate()
         self.expr_hoister.licm(**kwargs)
 
     def expand(self, mode='standard', **kwargs):

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -894,6 +894,9 @@ class ExpressionFactorizer(object):
                 return self.operands_ast
             elif len(self.operands) == 0:
                 return self.factors_ast
+            elif len(self.factors) == 1 and \
+                    all(isinstance(i, Symbol) and i.symbol == 1.0 for i in self.factors):
+                return self.operands_ast
             else:
                 return Prod(self.operands_ast, self.factors_ast)
 
@@ -968,7 +971,5 @@ class ExpressionFactorizer(object):
             raise RuntimeError("Factorization error: unknown node: %s" % str(node))
 
     def factorize(self, should_factorize):
-        if not isinstance(self.stmt, Writer):
-            return
         self.should_factorize = should_factorize
         self._factorize(self.stmt.rvalue, self.stmt)

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -317,7 +317,7 @@ class ExpressionRewriter(object):
                 # So if this condition fails, we give up
                 return
             # At this point, tensors can be reduced along the reducible dimensions
-            reducible_syms = [s for s in expr_syms if s.rank]
+            reducible_syms = [s for s in expr_syms if not s.is_const]
             # All involved symbols must result from hoisting
             if not all([s.symbol in self.hoisted for s in reducible_syms]):
                 return
@@ -364,6 +364,10 @@ class ExpressionRewriter(object):
                 hoisted.decl.init = values
                 hoisted.decl.qual = ['static', 'const']
                 self.hoisted.pop(s.symbol)
+                # Move all decls at the top of the kernel
+                self.header.children.remove(hoisted.decl)
+                self.header.children.insert(0, hoisted.decl)
+            self.header.children.insert(0, FlatBlock("// Preevaluated tables"))
             # Clean up
             self.header.children.remove(hoisted_loop)
 

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -346,7 +346,7 @@ class ExpressionRewriter(object):
         # Precompute constant expressions
         evaluator = Evaluate(self.decls, any(d.nonzero for s, d in self.decls.items()))
         for hoisted_loop in self.hoisted.all_loops:
-            evals = evaluator.visit(hoisted_loop, env=Evaluate.default_env)
+            evals = evaluator.visit(hoisted_loop, **Evaluate.default_args)
             # First, find out identical tables
             mapper = defaultdict(list)
             for s, values in evals.items():

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -578,8 +578,7 @@ class ExpressionHoister(object):
                     symbols[s] = dep
 
                 # 5) Create the body containing invariant statements
-                subexprs = [Par(dcopy(e)) if not isinstance(e, Par) else
-                            dcopy(e) for e in subexprs]
+                subexprs = [dcopy(e) for e in subexprs]
                 inv_stmts = [Assign(s, e) for s, e in zip(dcopy(inv_syms), subexprs)]
 
                 # 6) Track necessary information for AST construction
@@ -664,7 +663,7 @@ class ExpressionExpander(object):
             return {exp: self.cache[cache_key]}
 
         # Aliases
-        hoisted_expr = self.hoisted[exp.symbol].stmt.children[1]
+        hoisted_stmt = self.hoisted[exp.symbol].stmt
         hoisted_decl = self.hoisted[exp.symbol].decl
         hoisted_loop = self.hoisted[exp.symbol].loop
         hoisted_place = self.hoisted[exp.symbol].place
@@ -684,13 +683,13 @@ class ExpressionExpander(object):
 
         # No dependencies, just perform the expansion
         if not self.expr_graph.is_read(exp):
-            hoisted_expr.children[0] = op(Par(hoisted_expr.children[0]), dcopy(grp))
+            hoisted_stmt.children[1] = op(hoisted_stmt.children[1], dcopy(grp))
             self.expr_graph.add_dependency(exp, grp)
             self.cache[cache_key] = exp
             return {exp: exp}
 
         # Create new symbol, expression, and declaration
-        expr = Par(op(dcopy(exp), grp))
+        expr = op(dcopy(exp), grp)
         hoisted_exp = dcopy(exp)
         hoisted_exp.symbol = self._expanded_sym % {'loop_dep': exp.symbol,
                                                    'expr_id': self.expr_id,

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -296,7 +296,7 @@ class ExpressionRewriter(object):
                 # Create the reassociated product and modify the original AST
                 children = zip(*other_nodes)[0] if other_nodes else ()
                 children += tuple(sorted(symbols, key=reorder))
-                reassociated_node = ast_make_expr(Prod, children)
+                reassociated_node = ast_make_expr(Prod, children, balance=False)
                 parent.children[parent.children.index(node)] = reassociated_node
 
             else:

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -503,7 +503,7 @@ def check_type(stmt, decls):
     return type(lhs_decl)
 
 
-def find_expression(node, type, dims=None, in_syms=None, out_syms=None):
+def find_expression(node, type=None, dims=None, in_syms=None, out_syms=None):
     """Wrapper of the FindExpression visitor."""
     finder = FindExpression(type, dims, in_syms, out_syms)
     exprs = finder.visit(node, ret=FindExpression.default_retval())

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -299,7 +299,7 @@ def ast_make_for(stmts, loop, copy=False):
     return new_loop
 
 
-def ast_make_expr(op, nodes, balance=False):
+def ast_make_expr(op, nodes, balance=True):
     """Create an ``Expr`` Node of type ``op``, with children given in ``nodes``."""
 
     def _ast_make_expr(nodes):

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -503,7 +503,7 @@ def check_type(stmt, decls):
 def find_expression(node, e_type, e_dims=None, e_symbol=None):
     """Wrapper of the FindExpression visitor."""
     finder = FindExpression(e_type, e_dims, e_symbol)
-    exprs = finder.visit(node, env=FindExpression.default_env)
+    exprs = finder.visit(node, ret=FindExpression.default_retval())
     if 'matched_syms' in exprs:
         exprs.pop('matched_syms')
     if 'inner_syms' in exprs:

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -414,6 +414,9 @@ def explore_operator(node):
             else:
                 children.append((n, node))
 
+    while isinstance(node, Par):
+        node = node.child
+
     children = []
     _explore_operator(node, node.__class__, children)
     return children

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -33,7 +33,6 @@
 
 """Utility functions for the transformation of ASTs."""
 
-import resource
 import operator
 from warnings import warn as warning
 from copy import deepcopy as dcopy
@@ -41,30 +40,6 @@ from collections import defaultdict
 
 from base import *
 from coffee.visitors.inspectors import *
-
-
-def increase_stack(loop_opts):
-    """"Increase the stack size it the total space occupied by the kernel's local
-    arrays is too big."""
-    # Assume the size of a C type double is 8 bytes
-    double_size = 8
-    # Assume the stack size is 1.7 MB (2 MB is usually the limit)
-    stack_size = 1.7*1024*1024
-
-    size = 0
-    for loop_opt in loop_opts:
-        decls = loop_opt.decls.values()
-        size += sum([reduce(operator.mul, d.sym.rank) for d in decls if d.sym.rank])
-
-    if size*double_size > stack_size:
-        # Increase the stack size if the kernel's stack size seems to outreach
-        # the space available
-        try:
-            resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY,
-                                                       resource.RLIM_INFINITY))
-        except resource.error:
-            warning("Stack may blow up, and could not increase its size.")
-            warning("In case of failure, lower COFFEE's licm level to 1.")
 
 
 def unroll_factors(loops):

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -586,12 +586,13 @@ class ItSpace():
         """
         itspaces = self._convert_to_mode0(itspaces)
 
-        if len(itspaces) in [0, 1]:
+        if len(itspaces) == 0:
             return ()
-        itspaces = [set(range(i[0], i[1])) for i in itspaces]
-        itspace = set.intersection(*itspaces)
-        itspace = sorted(list(itspace)) or [0, -1]
-        itspaces = [(itspace[0], itspace[-1]+1)]
+        elif len(itspaces) > 1:
+            itspaces = [set(range(i[0], i[1])) for i in itspaces]
+            itspace = set.intersection(*itspaces)
+            itspace = sorted(list(itspace)) or [0, -1]
+            itspaces = [(itspace[0], itspace[-1]+1)]
 
         itspace = self._convert_from_mode0(itspaces)[0]
         return itspace

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -501,8 +501,10 @@ def find_expression(node, e_type, e_dims=None, e_symbol=None):
     """Wrapper of the FindExpression visitor."""
     finder = FindExpression(e_type, e_dims, e_symbol)
     exprs = finder.visit(node, env=FindExpression.default_env)
-    if 'in_syms' in exprs:
-        exprs.pop('in_syms')
+    if 'matched_syms' in exprs:
+        exprs.pop('matched_syms')
+    if 'inner_syms' in exprs:
+        exprs.pop('inner_syms')
     if 'in_itspace' in exprs:
         exprs.pop('in_itspace')
     return exprs

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -503,12 +503,16 @@ def check_type(stmt, decls):
     return type(lhs_decl)
 
 
-def find_expression(node, e_type, e_dims=None, e_symbol=None):
+def find_expression(node, type, dims=None, in_syms=None, out_syms=None):
     """Wrapper of the FindExpression visitor."""
-    finder = FindExpression(e_type, e_dims, e_symbol)
+    finder = FindExpression(type, dims, in_syms, out_syms)
     exprs = finder.visit(node, ret=FindExpression.default_retval())
-    if 'matched_syms' in exprs:
-        exprs.pop('matched_syms')
+    if 'cleaned' in exprs:
+        exprs.pop('cleaned')
+    if 'in_syms' in exprs:
+        exprs.pop('in_syms')
+    if 'out_syms' in exprs:
+        exprs.pop('out_syms')
     if 'inner_syms' in exprs:
         exprs.pop('inner_syms')
     if 'in_itspace' in exprs:

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -33,8 +33,6 @@
 
 """Utility functions for the transformation of ASTs."""
 
-import operator
-from warnings import warn as warning
 from copy import deepcopy as dcopy
 from collections import defaultdict
 

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -299,16 +299,23 @@ def ast_make_for(stmts, loop, copy=False):
     return new_loop
 
 
-def ast_make_expr(op, nodes):
+def ast_make_expr(op, nodes, balance=False):
     """Create an ``Expr`` Node of type ``op``, with children given in ``nodes``."""
 
     def _ast_make_expr(nodes):
         return nodes[0] if len(nodes) == 1 else op(nodes[0], _ast_make_expr(nodes[1:]))
 
-    try:
-        return _ast_make_expr(nodes)
-    except IndexError:
+    def _ast_make_bal_expr(nodes):
+        half = len(nodes) / 2
+        return nodes[0] if len(nodes) == 1 else op(_ast_make_bal_expr(nodes[:half]),
+                                                   _ast_make_bal_expr(nodes[half:]))
+
+    if len(nodes) == 0:
         return None
+    elif balance:
+        return _ast_make_bal_expr(nodes)
+    else:
+        return _ast_make_expr(nodes)
 
 
 def ast_make_alias(node1, node2):

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -524,6 +524,17 @@ def check_type(stmt, decls):
     return type(lhs_decl)
 
 
+def find_expression(node, e_type, e_dims=None, e_symbol=None):
+    """Wrapper of the FindExpression visitor."""
+    finder = FindExpression(e_type, e_dims, e_symbol)
+    exprs = finder.visit(node, env=FindExpression.default_env)
+    if 'in_syms' in exprs:
+        exprs.pop('in_syms')
+    if 'in_itspace' in exprs:
+        exprs.pop('in_itspace')
+    return exprs
+
+
 #######################################################################
 # Functions to manipulate iteration spaces in various representations #
 #######################################################################

--- a/coffee/vectorizer.py
+++ b/coffee/vectorizer.py
@@ -306,11 +306,12 @@ class LoopVectorizer(object):
                         if i >= decl.core[p_dim]:
                             # In the padded region, safe
                             continue
-                        nz_s = self.nz_syms.get(s.symbol, [((0, 0),)])[p_dim]
-                        if any(i in range(j[1], j[0] + j[1]) for j in nz_s):
-                            # The i-th extra iteration does not fall in a zero-valued
-                            # region, so we should not round
-                            should_round = False
+                        for j in self.expr_graph.readers(s.symbol) + [s.symbol]:
+                            nz_s = self.nz_syms.get(j, self.decls[j].core)
+                            if any(i in range(k[1], k[0] + k[1]) for k in nz_s[p_dim]):
+                                # The i-th extra iteration does not fall in a zero-valued
+                                # region, so we should not round
+                                should_round = False
                     # Round down the start point
                     ast_update_ofs(s, {l.dim: start})
                     # Track the modified lvalues

--- a/coffee/visitors/inspectors.py
+++ b/coffee/visitors/inspectors.py
@@ -592,7 +592,8 @@ class FindExpression(Visitor):
     Visit the expression tree and return a list of (sub-)expressions matching
     particular criteria.
 
-    :arg type: establish the expressions' root operator(s) (e.g., Sum, Sub, ...).
+    :arg type: (optional) establish the matching expression' root operator(s),
+        such as Sum, Sub, ...
     :arg dims: (optional) a tuple, each entry representing an iteration space
         dimension. Expressions' symbols must iterate along one of these iteration
         space dimensions.
@@ -602,7 +603,7 @@ class FindExpression(Visitor):
         this argument.
     """
 
-    def __init__(self, type, dims=None, in_syms=None, out_syms=None):
+    def __init__(self, type=None, dims=None, in_syms=None, out_syms=None):
         self.type = type
         self.dims = dims
         self.in_syms = in_syms
@@ -622,8 +623,8 @@ class FindExpression(Visitor):
             key = set(ret['in_syms'])
             key |= {j for j in ret['inner_syms']}
             key = tuple(sorted(key))
-            if isinstance(o, self.type):
-                if isinstance(parent, self.type):
+            if not self.type or isinstance(o, self.type):
+                if self.type and isinstance(parent, self.type):
                     # Postpone expression tracking because the parent has same type
                     # as the node currently being visited
                     pass

--- a/coffee/visitors/inspectors.py
+++ b/coffee/visitors/inspectors.py
@@ -596,14 +596,17 @@ class FindExpression(Visitor):
     :arg dims: (optional) a tuple, each entry representing an iteration space
         dimension. Expressions' symbols must iterate along one of these iteration
         space dimensions.
-    :arg symbols: (optional) expressions must include at least one of the symbols
+    :arg in_syms: (optional) expressions must include at least one of the symbols
         in this argument.
+    :arg out_syms: (optional) expressions must exclude all of the symbols in
+        this argument.
     """
 
-    def __init__(self, type, dims=None, symbols=None):
+    def __init__(self, type, dims=None, in_syms=None, out_syms=None):
         self.type = type
         self.dims = dims
-        self.symbols = symbols
+        self.in_syms = in_syms
+        self.out_syms = out_syms or []
         super(FindExpression, self).__init__()
 
     def visit_object(self, o, *args, **kwargs):
@@ -614,33 +617,45 @@ class FindExpression(Visitor):
         for i in [self.visit(n, parent=o, *args, **kwargs) for n in o.children]:
             for k, v in i.items():
                 ret[k].extend([j for j in v if j not in ret[k]])
-        if all(i in ret for i in ['matched_syms', 'in_itspace']):
+        if not ret['cleaned'] and all(i in ret for i in ['in_syms', 'in_itspace']):
+            # Create key for expression /o/
+            key = set(ret['in_syms'])
+            key |= {j for j in ret['inner_syms']}
+            key = tuple(sorted(key))
             if isinstance(o, self.type):
                 if isinstance(parent, self.type):
                     # Postpone expression tracking because the parent has same type
                     # as the node currently being visited
                     pass
                 else:
-                    key = set(ret['matched_syms'])
-                    key |= {j for j in ret['inner_syms']}
-                    key = tuple(sorted(key))
                     # Pop inner subexpressions, than push the parent one, since
                     # it represents a larger match
                     for k, v in ret.items():
                         if set(k).issubset(key):
                             ret.pop(k)
-                    ret[key] = [o]
+                    # Does this subexpression /o/ include any of the forbidden symbols ?
+                    if not any(i in key for i in ret['out_syms']):
+                        # Yay, NO, track it
+                        ret[key] = [o]
+                    else:
+                        # Yes. The first time we match an /out_sym/ we still have to go
+                        # through the /else/ above to remove the inner subexpressions,
+                        # but we should do it only once. 'cleaned' prevents popping
+                        # from happening multiple times
+                        ret['cleaned'] = [True]
             else:
-                ret.pop('matched_syms')
+                ret.pop('in_syms')
         return ret
 
     visit_FunCall = visit_Expr
 
     def visit_Symbol(self, o, *args, **kwargs):
         ret = self.default_retval()
-        if self.symbols is None or o.symbol in self.symbols:
-            ret['matched_syms'] = [o.symbol]
+        if self.in_syms is None or o.symbol in self.in_syms:
+            ret['in_syms'] = [o.symbol]
             ret['inner_syms'] = [o.symbol]
+        if o.symbol in self.out_syms:
+            ret['out_syms'] = [o.symbol]
         if self.dims is None or any(r in self.dims for r in o.rank):
             ret['in_itspace'] = [True]
         return ret

--- a/coffee/visitors/utilities.py
+++ b/coffee/visitors/utilities.py
@@ -8,11 +8,11 @@ import numpy as np
 
 from coffee.visitor import Visitor, Environment
 from coffee.base import Sum, Sub, Prod, Div, SparseArrayInit
-from coffee.utils import ItSpace
+from coffee.utils import ItSpace, flatten
 
 
 __all__ = ["ReplaceSymbols", "CheckUniqueness", "Uniquify", "Evaluate",
-           "EstimateFlops"]
+           "EstimateFlops", "ProjectExpansion"]
 
 
 class ReplaceSymbols(Visitor):
@@ -219,6 +219,60 @@ class Evaluate(Visitor):
                 # .../r/ is a reduction dimension
                 values = values.take(range(s), dim)
         return values, precision
+
+
+class ProjectExpansion(Visitor):
+    """
+    Project the output of expression expansion.
+    The caller should provid a collection of symbols C. The expression tree (nodes
+    that are not of type :class:`~.Expr` are not allowed) is visited and, for
+    each symbol in C, return a list of tuples. Each tuple represents a subset of
+    the symbols in C that will appear in the same term after expansion.
+
+    For example, be C = [A, B], and consider the following input expression: ::
+
+        (A*C + D*E)*(B*C + B*F)
+
+    After expansion, the expression becomes: ::
+
+        A*C*B*C + A*C*B*F + D*E*B*C + D*E*B*F
+
+    In which there are four product terms. In these terms, there are two in which
+    both A and B appear, and there are two in which only B appears. So the visit
+    would return [(A, B), (B,)].
+
+    :arg symbols: the collection of symbols searched for
+    """
+
+    def __init__(self, symbols):
+        self.symbols = symbols
+        super(ProjectExpansion, self).__init__()
+
+    def visit_object(self, o, env):
+        return []
+
+    def visit_Expr(self, o, env):
+        children = []
+        for n in o.children:
+            children.extend(self.visit(n))
+        ret = []
+        for n in children:
+            if n not in ret:
+                ret.append(n)
+        return ret
+
+    def visit_Prod(self, o, env):
+        projection = [self.visit(n) for n in o.children]
+        product = itertools.product(*projection)
+        if not product:
+            return projection
+        ret = []
+        for i in product:
+            ret.append(list(flatten(i)))
+        return ret
+
+    def visit_Symbol(self, o, env):
+        return [[o.symbol]] if o.symbol in self.symbols else [[]]
 
 
 class EstimateFlops(Visitor):


### PR DESCRIPTION
This introduces a new optimization engine that aims to automatically apply an "optimal sequence of transformation steps" to arbitrary multilinear forms.

I'm writing a document (paper) to clarify what I mean by "optimal sequence of transformation steps", so I won't waste my (and your) time talking about it here.

I wanna clarify a few practical aspects:

* the new optimisation engine (O4) is essentially a superset of the optimisation mode O2 (O4 "uses" O2). So despite the huge amount of additions brought by this PR, things won't change (i.e. kernels won't be transformed differently) if O2 is actually in place (e.g. current Firedrake). This is on purpose, since O4 may need more time (and more people using it) to become stable. If O4 is switched on, however, all tests (even firedrake ones) at the moment pass, so one could start "beta testing" it.
* many (most!) changes are actually a refactoring or generalisation of ancient code

