### PR TITLE
TSFC + Vectorizer

### DIFF
--- a/coffee/base.py
+++ b/coffee/base.py
@@ -461,7 +461,7 @@ class Symbol(Expr):
         return not self.rank or all(is_const_dim(r) for r in self.rank)
 
     @property
-    def is_const_stride(self):
+    def is_const_offset(self):
         from utils import is_const_dim, flatten
         return not self.offset or all(is_const_dim(o) for o in flatten(self.offset))
 
@@ -472,6 +472,14 @@ class Symbol(Expr):
     @property
     def strides(self):
         return tuple(o[1] for o in self.offset)
+
+    @property
+    def is_unit_period(self):
+        return self.is_const_offset and all(i == 1 for i in self.periods)
+
+    @property
+    def is_unit_stride(self):
+        return self.is_const_offset and all(i == 1 for i in self.strides)
 
     @property
     def urepr(self):

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -726,12 +726,12 @@ class Decl(Writer):
     def size(self):
         """Return the size of the declared variable. In particular, return
 
-        * ``(0,)``, if it is a scalar
+        * ``()``, if it is a scalar
         * a tuple, if it is a N-dimensional array, such that each entry
           represents the size of an array dimension (e.g. ``double A[20][10]``
           -> ``(20, 10)``)
         """
-        return self.sym.rank or (0,)
+        return self.sym.rank or ()
 
     @property
     def core(self):

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -461,6 +461,11 @@ class Symbol(Expr):
         return all(is_const_dim(r) for r in self.rank)
 
     @property
+    def is_const_stride(self):
+        from utils import is_const_dim
+        return all(is_const_dim(o) for o in self.offset)
+
+    @property
     def urepr(self):
         """Provide a unique representation of Symbols having same name,
         iteration space, and offset."""

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -34,7 +34,6 @@
 """This file contains the hierarchy of classes that implement a kernel's
 Abstract Syntax Tree (AST)."""
 
-from collections import namedtuple
 from copy import deepcopy as dcopy
 from math import isnan
 import numbers
@@ -325,7 +324,6 @@ class SparseArrayInit(ArrayInit):
         """
         super(SparseArrayInit, self).__init__(values, precision)
 
-        # It's more practice to handle namedtuples
         from utils import Region
         nonzero = [[Region(size, ofs) for size, ofs in dim] for dim in nonzero]
         self.nonzero = tuple(nonzero)

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -462,8 +462,16 @@ class Symbol(Expr):
 
     @property
     def is_const_stride(self):
-        from utils import is_const_dim
-        return not self.offset or all(is_const_dim(o) for o in self.offset)
+        from utils import is_const_dim, flatten
+        return not self.offset or all(is_const_dim(o) for o in flatten(self.offset))
+
+    @property
+    def periods(self):
+        return tuple(o[0] for o in self.offset)
+
+    @property
+    def strides(self):
+        return tuple(o[1] for o in self.offset)
 
     @property
     def urepr(self):

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -458,12 +458,12 @@ class Symbol(Expr):
     @property
     def is_const(self):
         from utils import is_const_dim
-        return all(is_const_dim(r) for r in self.rank)
+        return not self.rank or all(is_const_dim(r) for r in self.rank)
 
     @property
     def is_const_stride(self):
         from utils import is_const_dim
-        return all(is_const_dim(o) for o in self.offset)
+        return not self.offset or all(is_const_dim(o) for o in self.offset)
 
     @property
     def urepr(self):

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -34,6 +34,7 @@
 """This file contains the hierarchy of classes that implement a kernel's
 Abstract Syntax Tree (AST)."""
 
+from collections import namedtuple
 from copy import deepcopy as dcopy
 from math import isnan
 import numbers
@@ -323,7 +324,11 @@ class SparseArrayInit(ArrayInit):
             (1-2 and 3) and one group of non zero-valued columns
         """
         super(SparseArrayInit, self).__init__(values, precision)
-        self.nonzero = nonzero
+
+        # It's more practice to handle namedtuples
+        from utils import Region
+        nonzero = [[Region(size, ofs) for size, ofs in dim] for dim in nonzero]
+        self.nonzero = tuple(nonzero)
 
     def reconstruct(self, values, precision, nonzero, **kwargs):
         return type(self)(values, precision, nonzero, **kwargs)

--- a/coffee/citations.py
+++ b/coffee/citations.py
@@ -1,0 +1,53 @@
+# This file is part of COFFEE
+#
+# COFFEE is Copyright (c) 2016, Imperial College London.
+# Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Handle article citations based on the employed optimizations."""
+
+def update_citations(params):
+    """Update citations list for the known COFFEE users."""
+
+    # Firedrake
+    try:
+        from firedrake import Citations
+        rewrite = params.get('rewrite', 0)
+        nozeros = params.get('dead_ops_elimination', False)
+        align_pad = params.get('align_pad', False)
+        vectorize = params.get('vectorize', False)
+        split = params.get('split', False)
+
+        if rewrite == 1 or align_pad or vectorize or split:
+            Citations().register('Luporini2015')
+        if rewrite > 1 or nozeros:
+            Citations().register('Luporini2016')
+    except ImportError:
+        pass

--- a/coffee/citations.py
+++ b/coffee/citations.py
@@ -33,6 +33,7 @@
 
 """Handle article citations based on the employed optimizations."""
 
+
 def update_citations(params):
     """Update citations list for the known COFFEE users."""
 

--- a/coffee/citations.py
+++ b/coffee/citations.py
@@ -34,8 +34,21 @@
 """Handle article citations based on the employed optimizations."""
 
 
+# Papers describing COFFEE
+LUPORINI2015 = """
+Fabio Luporini and Ana Lucia Varbanescu and Florian Rathgeber and Gheorghe-Teodor Bercea \
+and J. Ramanujam and David A. Ham and Paul H. J. Kelly. Cross-Loop Optimization of \
+Arithmetic Intensity for Finite Element Local Assembly. ACM Transactions on Architecture \
+and Code Optimization, 2015.
+"""
+LUPORINI2016 = """
+Fabio Luporini and David A. Ham and Paul H. J. Kelly. An algorithm for the optimization \
+of finite element integration loops. Submitted to ACM TOMS, 2016.
+"""
+
+
 def update_citations(params):
-    """Update citations list for the known COFFEE users."""
+    """Update citations list for known COFFEE users."""
 
     # Firedrake
     try:

--- a/coffee/hoister.py
+++ b/coffee/hoister.py
@@ -390,8 +390,8 @@ class Hoister(object):
                             'i': i
                         }
                         stmts.append(Assign(Symbol(name, loop_dim), dcopy(e)))
-                        decl = Decl(self.expr_info.type, Symbol(name, loop_size))
-                        decl.scope = LOCAL
+                        decl = Decl(self.expr_info.type, Symbol(name, loop_size),
+                                    scope=LOCAL)
                         decls.append(decl)
                         self.decls[name] = decl
                     symbols.append(Symbol(name, loop_dim))

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -36,6 +36,7 @@
 import system
 from base import *
 from utils import *
+from citations import update_citations
 from optimizer import CPULoopOptimizer, GPULoopOptimizer
 from vectorizer import LoopVectorizer, VectStrategy
 from expression import MetaExpr
@@ -164,6 +165,8 @@ class ASTKernel(object):
             params = {}
         else:
             params = opts
+
+        update_citations(params)
 
         # The optimization passes are performed individually (i.e., "locally") for
         # each function (or "kernel") found in the provided AST

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -148,6 +148,7 @@ class ASTKernel(object):
         elif opts.get('O3'):
             params = {
                 'rewrite': 2,
+                'align_pad': True,
                 'dead_ops_elimination': True
             }
         elif opts.get('O2'):

--- a/coffee/system.py
+++ b/coffee/system.py
@@ -136,8 +136,6 @@ def coffee_init(**kwargs):
 def coffee_reconfigure(**kwargs):
     """Reconfigure the internal state of COFFEE."""
 
-    global options
-
     options['optimizations'] = kwargs.get('optlevel')
 
 
@@ -265,16 +263,6 @@ def set_isa(isa_id):
         }
 
     return {}
-
-
-def set_min_log_level():
-    """Minimize logging output."""
-    global options
-    options['logging'] = 'func_warning'
-
-
-def set_max_log_level():
-    """Maximize logging output."""
 
 
 O0 = OptimizationLevel('O0')

--- a/coffee/system.py
+++ b/coffee/system.py
@@ -191,7 +191,7 @@ def set_compiler(compiler_id):
         * 'intel' (aka icc)
     """
 
-    if compiler == 'gnu':
+    if compiler_id == 'gnu':
         return {
             'name': 'gnu',
             'cmd': 'gcc',
@@ -205,7 +205,7 @@ def set_compiler(compiler_id):
             'vect_header': '#include <immintrin.h>'
         }
 
-    if compiler == 'intel':
+    if compiler_id == 'intel':
         return {
             'name': 'intel',
             'cmd': 'icc',
@@ -229,7 +229,7 @@ def set_isa(isa_id):
         * 'avx'
     """
 
-    if isa == 'sse':
+    if isa_id == 'sse':
         return {
             'inst_set': 'SSE',
             'avail_reg': 16,
@@ -238,7 +238,7 @@ def set_isa(isa_id):
             'reg': lambda n: 'xmm%s' % n
         }
 
-    if isa == 'avx':
+    if isa_id == 'avx':
         return {
             'inst_set': 'AVX',
             'avail_reg': 16,

--- a/coffee/system.py
+++ b/coffee/system.py
@@ -36,10 +36,13 @@
 import sys
 
 from base import *
-from logger import LOG_DEFAULT, set_log_level
+from citations import update_citations
+from vectorizer import VectStrategy
+from logger import LOG_DEFAULT, set_log_level, warn
 
 
-__all__ = ['arch', 'compiler', 'isa', 'options', 'initialized']
+__all__ = ['architecture', 'compiler', 'isa', 'options', 'initialized',
+           'O0', 'O1', 'O2', 'O3', 'Ofast']
 
 
 class Options(dict):
@@ -61,22 +64,57 @@ class Options(dict):
             self._callbacks[key](value)
 
 
-initialized = False
-options = Options()
+class OptimizationLevel(dict):
 
-architecture = {}
-compiler = {}
-isa = {}  # Instruction Set Architecture
+    _KNOWN = {}
+
+    @classmethod
+    def retrieve(cls, optlevel):
+        """Retrieve the set of transformations corresponding to ``optlevel``.
+
+        :param optlevel: may be an :class:`OptimizationLevel` itself (in which
+        case ``optlevel`` itself is returned) or the name of the level (a string).
+        """
+        if isinstance(optlevel, OptimizationLevel):
+            return optlevel
+        elif isinstance(optlevel, str) and optlevel in cls._KNOWN:
+            return cls._KNOWN[optlevel]
+        elif not optlevel:
+            return O0
+        else:
+            warn("Unrecognized optimization specified.")
+            return O0
+
+    def __init__(self, name, **kwargs):
+        self.name = name
+
+        for key, value in kwargs.iteritems():
+            self[key] = value
+
+        OptimizationLevel._KNOWN[name] = self
 
 
 def coffee_init(**kwargs):
-    """Initialize COFFEE."""
+    """Initialize COFFEE.
+
+    :param compiler: Options: ``gnu``, ``intel``. By knowing the backend compiler,
+        COFFEE can generate specialized code (e.g., by inserting suitable loop pragmas).
+    :param isa: Options: ``sse``, ``avx``. The instruction set architecture tells
+        COFFEE the vector length and the available intrinsics so that optimized
+        vector code (or scalar code suitable for compiler auto-vectorization) is
+        generated.
+    :param architecture: Options: ``default``, ``intel``.
+    :param optlevel: Options: ``O0`` (default), ``O1``, ``O2``, ``O3``, ``Ofast``.
+        The higher the optimization level, the more aggresively are the transformations.
+        For more details, refer to the ``set_opt_level``'s documentation.
+    """
 
     global initialized, options, architecture, compiler, isa
 
     architecture_id = kwargs.get('architecture', 'default')
     compiler_id = kwargs.get('compiler')
     isa_id = kwargs.get('isa')
+    optlevel = kwargs.get('optlevel', O0)
 
     architecture = set_architecture(architecture_id)
     compiler = set_compiler(compiler_id)
@@ -85,14 +123,49 @@ def coffee_init(**kwargs):
     if all([architecture, compiler, isa]):
         initialized = True
 
-    options.register('logging', LOG_DEFAULT, set_log_level)
-    options.register('architecture', architecture_id, set_architecture)
-    options.register('compiler', compiler_id, set_compiler)
-    options.register('isa', isa_id, set_isa)
+    options['architecture'] = architecture_id
+    options['compiler'] = compiler_id
+    options['isa'] = isa_id
+    options['optimizations'] = optlevel
 
     # Allow visits of ASTs that become huge due to transformation. The constant
     # /4000/ was empirically found to be an acceptable value
     sys.setrecursionlimit(4000)
+
+
+def coffee_reconfigure(**kwargs):
+    """Reconfigure the internal state of COFFEE."""
+
+    global options
+
+    options['optimizations'] = kwargs.get('optlevel')
+
+
+def set_opt_level(optlevel):
+    """Set the default optimization level.
+
+    :param optlevel: accepted values are: ::
+
+        ``O0``: No optimizations are applied at all (default).
+        ``O1``: Apply generalized loop-invariant code motion. Refer to
+            ``citations.LUPORINI2015`` for more information.
+        ``O2``: Apply sharing elimination and elimination of useless floating
+            point operations (e.g., a + 0 == a). Refer to ``citations.LUPORINI2016``
+            for more information.
+        ``O3``: Apply ``O2`` and enforce data alignment through array padding.
+            This maximizes the impact of compiler auto-vectorization, as thoroughly
+            discussed in ``citations.LUPORINI2015``.
+        ``Ofast``: Apply ``O3``, but resort to explicit outer-product vectorization
+            instead. Vector promotion is also attempted to maximize vectorization in
+            the outer loops. Refer to ``citations.LUPORINI2015`` for more information.
+
+        Alternatively, one can craft a new composite transformation by creating a
+        new :class:`OptimizationLevel`.
+    """
+
+    optimizations = OptimizationLevel.retrieve(optlevel)
+
+    update_citations(optimizations)
 
 
 def set_architecture(architecture_id):
@@ -202,3 +275,24 @@ def set_min_log_level():
 
 def set_max_log_level():
     """Maximize logging output."""
+
+
+O0 = OptimizationLevel('O0')
+O1 = OptimizationLevel('O1', rewrite=1)
+O2 = OptimizationLevel('O2', rewrite=2, dead_ops_elimination=True)
+O3 = OptimizationLevel('O3', align_pad=True, **O2)
+Ofast = OptimizationLevel('Ofast', vectorize=(VectStrategy.SPEC_UAJ_PADD, 2),
+                          precompute='noloops', **O3)
+
+initialized = False
+
+options = Options()
+options.register('logging', LOG_DEFAULT, set_log_level)
+options.register('architecture', callback=set_architecture)
+options.register('compiler', callback=set_compiler)
+options.register('isa', callback=set_isa)
+options.register('optimizations', O0.name, callback=set_opt_level)
+
+architecture = {}
+compiler = {}
+isa = {}  # Instruction Set Architecture

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -34,7 +34,7 @@
 """Utility functions for the inspection, transformation, and creation of ASTs."""
 
 from copy import deepcopy as dcopy
-from collections import defaultdict, OrderedDict
+from collections import defaultdict, OrderedDict, namedtuple
 
 import networkx as nx
 
@@ -532,7 +532,7 @@ class ItSpace(object):
         if self.mode == 0:
             return itspaces
         elif self.mode == 1:
-            return [(end-start, start) for start, end in itspaces]
+            return [Region(end-start, start) for start, end in itspaces]
         elif self.mode == 2:
             raise RuntimeError("Cannot convert from mode=0 to mode=2")
 
@@ -785,6 +785,14 @@ class ExpressionGraph(object):
     def reads(self, sym):
         """Return the list of symbol identifiers that ``sym`` reads from."""
         return [j for i, j in self.deps.out_edges(sym)]
+
+
+########################
+# Simple support types #
+########################
+
+
+Region = namedtuple('Region', ['size', 'ofs'])
 
 
 #############################

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -522,11 +522,11 @@ class ItSpace(object):
 
     def _convert_to_mode0(self, itspaces):
         if self.mode == 0:
-            return itspaces
+            return tuple(itspaces)
         elif self.mode == 1:
-            return [(ofs, ofs+size) for size, ofs in itspaces]
+            return tuple((ofs, ofs+size) for size, ofs in itspaces)
         elif self.mode == 2:
-            return [(l.start, l.end) for l in itspaces]
+            return tuple((l.start, l.end) for l in itspaces)
 
     def _convert_from_mode0(self, itspaces):
         if self.mode == 0:


### PR DESCRIPTION
Make COFFEE capable of applying padding and data alignment to TSFC kernels.

This transformation is compasable with all other transformations. However, it is *not* used by default Firedrake (this is activated at level O3, while Firedrake uses O2). The reason is that despite making most loops easily vectorisable, there are compilers (e.g., GCC ver < 5.0) rejecting auto-vectorisation when loops are too small or due to other non-sense reasons. Padding increases the loop trip counts, so it's (performance-wise) safer to switch it on only when sure that loops are gonna get vectorised.

Note: as I'll document properly and some of you already know, there is a non-trivial interplay between the zero-elimination transformation and padding, because of the introduction of offsets in the kernel (e.g., A[i+3]). This, in some cases, makes data alignment not possible. One should try both O2 and O3 when the performance of a specific kernel is really critical.

Ah, the PR also adds a mechanism to pick the proper citations depending on the set of optimisations applied (didn't bother creating a separate PR). As such, this PR has the (trivial) dependency firedrake #796