### PR TITLE
Interface clean-up

### DIFF
--- a/coffee/cse.py
+++ b/coffee/cse.py
@@ -34,7 +34,7 @@
 from sys import maxint
 import operator
 
-from plan import verbose
+from system import options
 from base import *
 from utils import *
 from coffee.visitors import EstimateFlops
@@ -382,7 +382,7 @@ class CSEUnpicker(object):
 
             cse = self._cost_cse(fact_levels, (level + 1, bounds[1]))
 
-        if verbose:
+        if options['verbose']:
             print BLUE % ("Cost model :: unpicking CSE between levels [%d, %d]:" % bounds),
             print BLUE % ("cost=%d (cse=%d, outloop=%d, inloop_fact=%d, inloop_cse=%d)" %
                           (uptolevel_cost, cse_cost, total_outloop_cost,
@@ -424,7 +424,7 @@ class CSEUnpicker(object):
                 if local_best[2] < global_best[2]:
                     global_best = local_best
 
-            if verbose:
+            if options['verbose']:
                 print BLUE % ("Cost_model :: Best [%d, %d] (cost=%d)" % global_best)
 
             # Transform the loop

--- a/coffee/cse.py
+++ b/coffee/cse.py
@@ -34,11 +34,11 @@
 from sys import maxint
 import operator
 
-from system import options
 from base import *
 from utils import *
 from coffee.visitors import EstimateFlops
 from expression import MetaExpr
+from logger import Logger
 
 
 class Temporary(object):
@@ -382,11 +382,10 @@ class CSEUnpicker(object):
 
             cse = self._cost_cse(fact_levels, (level + 1, bounds[1]))
 
-        if options['verbose']:
-            print BLUE % ("Cost model :: unpicking CSE between levels [%d, %d]:" % bounds),
-            print BLUE % ("cost=%d (cse=%d, outloop=%d, inloop_fact=%d, inloop_cse=%d)" %
-                          (uptolevel_cost, cse_cost, total_outloop_cost,
-                           level_inloop_cost, cse))
+        Logger.out('CSE :: unpicking between levels [%d, %d]:' % bounds, 'verbose')
+        Logger.out('CSE :: cost=%d (cse=%d, outloop=%d, inloop_fact=%d, inloop_cse=%d)' %
+                   (uptolevel_cost, cse_cost, total_outloop_cost, level_inloop_cost, cse),
+                   'verbose')
 
         return best
 
@@ -424,8 +423,7 @@ class CSEUnpicker(object):
                 if local_best[2] < global_best[2]:
                     global_best = local_best
 
-            if options['verbose']:
-                print BLUE % ("Cost_model :: Best [%d, %d] (cost=%d)" % global_best)
+            Logger.out("Cost_model :: Best [%d, %d] (cost=%d)" % global_best, 'verbose')
 
             # Transform the loop
             for i in range(global_best[0] + 1, global_best[1] + 1):

--- a/coffee/cse.py
+++ b/coffee/cse.py
@@ -38,7 +38,7 @@ from base import *
 from utils import *
 from coffee.visitors import EstimateFlops
 from expression import MetaExpr
-from logger import Logger
+from logger import log, COST_MODEL
 
 
 class Temporary(object):
@@ -382,10 +382,9 @@ class CSEUnpicker(object):
 
             cse = self._cost_cse(fact_levels, (level + 1, bounds[1]))
 
-        Logger.out('CSE :: unpicking between levels [%d, %d]:' % bounds, 'verbose')
-        Logger.out('CSE :: cost=%d (cse=%d, outloop=%d, inloop_fact=%d, inloop_cse=%d)' %
-                   (uptolevel_cost, cse_cost, total_outloop_cost, level_inloop_cost, cse),
-                   'verbose')
+        log('CSE: unpicking between levels [%d, %d]:' % bounds, COST_MODEL)
+        log('CSE: cost=%d (cse=%d, outloop=%d, inloop_fact=%d, inloop_cse=%d)' %
+            (uptolevel_cost, cse_cost, total_outloop_cost, level_inloop_cost, cse), COST_MODEL)
 
         return best
 
@@ -423,7 +422,7 @@ class CSEUnpicker(object):
                 if local_best[2] < global_best[2]:
                     global_best = local_best
 
-            Logger.out("Cost_model :: Best [%d, %d] (cost=%d)" % global_best, 'verbose')
+            log("-- Best: [%d, %d] (cost=%d) --" % global_best, COST_MODEL)
 
             # Transform the loop
             for i in range(global_best[0] + 1, global_best[1] + 1):

--- a/coffee/hoister.py
+++ b/coffee/hoister.py
@@ -31,10 +31,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from warnings import warn as warning
-
 from base import *
 from utils import *
+from logger import Logger
 
 
 class Extractor(object):
@@ -367,7 +366,7 @@ class Hoister(object):
                         wrap_loop = ()
                         offset = place.children[place.children.index(self.stmt)]
                 else:
-                    warning("Unexpected code motion case. Skipping.")
+                    Logger.out("Skipping unexpected code motion case.", "func_warning")
                     return
 
                 loop_size = tuple([l.size for l in wrap_loop])

--- a/coffee/hoister.py
+++ b/coffee/hoister.py
@@ -33,7 +33,7 @@
 
 from base import *
 from utils import *
-from logger import Logger
+from logger import warn
 
 
 class Extractor(object):
@@ -366,7 +366,7 @@ class Hoister(object):
                         wrap_loop = ()
                         offset = place.children[place.children.index(self.stmt)]
                 else:
-                    Logger.out("Skipping unexpected code motion case.", "func_warning")
+                    warn("Skipping unexpected code motion case.")
                     return
 
                 loop_size = tuple([l.size for l in wrap_loop])

--- a/coffee/logger.py
+++ b/coffee/logger.py
@@ -33,14 +33,8 @@
 
 """The COFFEE logger."""
 
-from collections import OrderedDict
 import logging
 import sys
-try:
-    from mpi4py import MPI
-    rank = MPI.COMM_WORLD.Get_rank()
-except ImportError:
-    rank = 0
 
 
 logger = logging.getLogger('COFFEE')
@@ -68,16 +62,16 @@ RED = '\033[1;37;31m%s\033[0m'
 BLUE = '\033[1;37;34m%s\033[0m'
 GREEN = '\033[1;37;32m%s\033[0m'
 
-COLORS = OrderedDict([
-    (DEBUG, RED),
-    (INFO, GREEN),
-    (COST_MODEL, BLUE),
-    (PERF_OK, GREEN),
-    (PERF_WARN, BLUE),
-    (WARNING, BLUE),
-    (ERROR, RED),
-    (CRITICAL, RED)
-])
+COLORS = {
+    DEBUG: RED,
+    INFO: GREEN,
+    COST_MODEL: BLUE,
+    PERF_OK: GREEN,
+    PERF_WARN: BLUE,
+    WARNING: BLUE,
+    ERROR: RED,
+    CRITICAL: RED
+}
 
 
 def set_log_level(level):
@@ -104,9 +98,8 @@ def log(msg, level=INFO, *args, **kwargs):
     """
     assert level in [DEBUG, INFO, COST_MODEL, PERF_OK, PERF_WARN, WARNING, ERROR, CRITICAL]
 
-    if rank == 0:
-        color = COLORS[level] if sys.stdout.isatty() and sys.stderr.isatty() else '%s'
-        logger.log(level, color % msg, *args, **kwargs)
+    color = COLORS[level] if sys.stdout.isatty() and sys.stderr.isatty() else '%s'
+    logger.log(level, color % msg, *args, **kwargs)
 
 
 def warn(msg, *args, **kwargs):

--- a/coffee/logger.py
+++ b/coffee/logger.py
@@ -1,0 +1,99 @@
+# This file is part of COFFEE
+#
+# COFFEE is Copyright (c) 2016, Imperial College London.
+# Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Simple logging infrastructure."""
+
+from collections import OrderedDict
+import sys
+
+
+class Logger(object):
+    """Basic logging infrastructure."""
+
+    LEVELS = OrderedDict([
+        ('func_warning', '\033[1;37;31m%s\033[0m'),  # red
+        ('info', '\033[1;37;32m%s\033[0m'),  # green
+        ('perf_warning', '\033[1;37;34m%s\033[0m'),  # blue
+        ('verbose', '\033[1;37;34m%s\033[0m'),  # blue
+    ])
+
+    DEFAULT = 'info'
+    CURRENT = 'info'
+
+    @staticmethod
+    def out(output, level='info'):
+        """Print ``output`` if ``level`` is below the system verbosity threshold."""
+        assert level in Logger.LEVELS
+
+        msg_value = Logger.LEVELS.keys().index(level)
+        system_value = Logger.LEVELS.keys().index(Logger.CURRENT)
+
+        # Colors if the terminal supports it (disabled e.g. when piped to file)
+        if sys.stdout.isatty() and sys.stderr.isatty():
+            color = Logger.LEVELS[level]
+        else:
+            color = "%s"
+
+        if msg_value <= system_value:
+            print (color % output)
+
+    @staticmethod
+    def current():
+        """Get the current log level."""
+        return Logger.CURRENT
+
+    @staticmethod
+    def default():
+        """Get the default log level."""
+        return Logger.DEFAULT
+
+    @staticmethod
+    def reset_level():
+        """Set to the default log level."""
+        Logger.CURRENT = Logger.DEFAULT
+
+    @staticmethod
+    def set_level(level):
+        """Set a different log level."""
+        assert level in Logger.LEVELS
+        Logger.CURRENT = level
+
+    @staticmethod
+    def set_min_level():
+        """Set to minimum log level."""
+        Logger.CURRENT = 'func_warning'
+
+    @staticmethod
+    def set_max_level():
+        """Set to maximum log level."""
+        Logger.CURRENT = 'verbose'

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -38,7 +38,7 @@ from itertools import combinations
 from warnings import warn as warning
 from math import factorial as fact
 
-import plan
+import system
 from base import *
 from utils import *
 from scheduler import ExpressionFissioner, ZeroRemover, SSALoopMerger
@@ -372,7 +372,7 @@ class LoopOptimizer(object):
         # The memory threshold. The total size of temporaries will not have to
         # be greated than this value. If we predict that injection will lead
         # to too much temporary space, we have to partially drop it
-        threshold = plan.arch['cache_size'] * 1.2
+        threshold = system.architecture['cache_size'] * 1.2
 
         # 1) Find out and unroll injectable loops. For unrolling we create new
         # expressions; that is, for now, we do not modify the AST in place.
@@ -501,7 +501,7 @@ class LoopOptimizer(object):
                     # /cost/ * /sizeof(term)/.
                     size = [l.size for l in expr_info.linear_loops]
                     size = reduce(operator.mul, size, 1)
-                    storage_increase = cost * size * plan.arch[expr_info.type]
+                    storage_increase = cost * size * system.architecture[expr_info.type]
 
                     # Track the injectable sub-expression and its cost/save. The
                     # final decision of whether to actually perform injection or not

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -43,7 +43,7 @@ from utils import *
 from scheduler import ExpressionFissioner, ZeroRemover, SSALoopMerger
 from rewriter import ExpressionRewriter
 from cse import CSEUnpicker
-from logger import Logger
+from logger import warn
 from coffee.visitors import FindInstances, ProjectExpansion
 
 
@@ -609,7 +609,7 @@ class LoopOptimizer(object):
                 resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY,
                                                            resource.RLIM_INFINITY))
             except resource.error:
-                Logger.out("Stack may blow up, could not increase its size.", "func_warning")
+                warn("Stack may blow up, could not increase its size.")
 
     @property
     def expr_loops(self):

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -35,7 +35,6 @@ import operator
 import resource
 from collections import OrderedDict
 from itertools import combinations
-from warnings import warn as warning
 from math import factorial as fact
 
 import system
@@ -44,6 +43,7 @@ from utils import *
 from scheduler import ExpressionFissioner, ZeroRemover, SSALoopMerger
 from rewriter import ExpressionRewriter
 from cse import CSEUnpicker
+from logger import Logger
 from coffee.visitors import FindInstances, ProjectExpansion
 
 
@@ -609,7 +609,7 @@ class LoopOptimizer(object):
                 resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY,
                                                            resource.RLIM_INFINITY))
             except resource.error:
-                warning("Stack may blow up, and could not increase its size.")
+                Logger.out("Stack may blow up, could not increase its size.", "func_warning")
 
     @property
     def expr_loops(self):

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -37,7 +37,6 @@
 arch = {}
 compiler = {}
 isa = {}
-blas = {}
 verbose = False
 initialized = False
 
@@ -61,7 +60,6 @@ class ASTKernel(object):
     def __init__(self, ast, include_dirs=None):
         self.ast = ast
         self.include_dirs = include_dirs or []
-        self.blas = False
 
     def plan_cpu(self, opts):
         """Transform and optimize the kernel suitably for CPU execution."""
@@ -268,17 +266,16 @@ class ASTKernel(object):
         return self.ast.gencode()
 
 
-def init_coffee(_isa, _compiler, _blas, _arch='default'):
+def init_coffee(_isa, _compiler, _arch='default'):
     """Initialize COFFEE."""
 
-    global arch, isa, compiler, blas, initialized
+    global arch, isa, compiler, initialized
 
     # Populate dictionaries with keywords for backend-specific (hardware,
     # compiler, ...) optimizations
     arch = _init_arch(_arch)
     isa = _init_isa(_isa)
     compiler = _init_compiler(_compiler)
-    blas = _init_blas(_blas)
     if isa and compiler:
         initialized = True
 
@@ -377,16 +374,3 @@ def _init_compiler(compiler):
         }
 
     return {}
-
-
-def _init_blas(blas):
-    """Initialize a dictionary of blas-specific keywords for code generation."""
-
-    import os
-
-    blas_dict = {
-        'dir': os.environ.get("PYOP2_BLAS_DIR", ""),
-        'namespace': ''
-    }
-
-    return blas_dict

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -39,7 +39,7 @@ from utils import *
 from optimizer import CPULoopOptimizer, GPULoopOptimizer
 from vectorizer import LoopVectorizer, VectStrategy
 from expression import MetaExpr
-from logger import Logger
+from logger import log, warn, PERF_OK, PERF_WARN
 from coffee.visitors import FindInstances, EstimateFlops
 
 from collections import defaultdict, OrderedDict
@@ -82,13 +82,13 @@ class ASTKernel(object):
                          for (loop, header), exprs in nests.items()]
             # Combining certain optimizations is meaningless/forbidden.
             if dead_ops_elimination and split:
-                Logger.out("Split forbidden with dead-ops elimination", "func_warning")
+                warn("Split forbidden with dead-ops elimination")
                 return
             if dead_ops_elimination and v_type and v_type != VectStrategy.AUTO:
-                Logger.out("Vect forbidden with dead-ops elimination", "func_warning")
+                warn("Vect forbidden with dead-ops elimination")
                 return
             if rewrite == 'auto' and len(info['exprs']) > 1:
-                Logger.out("Rewrite auto forbidden with multiple exprs", "func_warning")
+                warn("Rewrite auto forbidden with multiple exprs")
                 rewrite = 4
 
             ### Optimization pipeline ###
@@ -176,10 +176,9 @@ class ASTKernel(object):
 
         tot_time = time.time() - start_time
 
-        out_string = "COFFEE finished in %g seconds (flops: %d -> %d)" % \
+        output = "COFFEE finished in %g seconds (flops: %d -> %d)" % \
             (tot_time, flops_pre, flops_post)
-        out_level = 'info' if flops_post <= flops_pre else 'perf_warning'
-        Logger.out(out_string, out_level)
+        log(output, PERF_OK if flops_post <= flops_pre else PERF_WARN)
 
     def plan_gpu(self):
         """Transform the kernel suitably for GPU execution.

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -33,13 +33,7 @@
 
 """COFFEE's optimization plan constructor."""
 
-# The following global variables capture the internal state of COFFEE
-arch = {}
-compiler = {}
-isa = {}
-verbose = False
-initialized = False
-
+import system
 from base import *
 from utils import *
 from optimizer import CPULoopOptimizer, GPULoopOptimizer
@@ -49,7 +43,6 @@ from coffee.visitors import FindInstances, EstimateFlops
 
 from collections import defaultdict, OrderedDict
 from warnings import warn as warning
-import sys
 import time
 
 
@@ -89,9 +82,11 @@ class ASTKernel(object):
                          for (loop, header), exprs in nests.items()]
             # Combining certain optimizations is meaningless/forbidden.
             if dead_ops_elimination and split:
-                raise RuntimeError("Split forbidden with zero-valued blocks avoidance")
+                warning("Split forbidden with zero-valued blocks avoidance")
+                return
             if dead_ops_elimination and v_type and v_type != VectStrategy.AUTO:
-                raise RuntimeError("SIMDization forbidden with zero-valued blocks avoidance")
+                warning("SIMDization forbidden with zero-valued blocks avoidance")
+                return
             if rewrite == 'auto' and len(info['exprs']) > 1:
                 warning("Rewrite mode=auto not supported with multiple expressions")
                 warning("Switching to rewrite mode=4")
@@ -116,14 +111,12 @@ class ASTKernel(object):
                     loop_opt.precompute(precompute)
 
                 # 4) Vectorization
-                if initialized and flatten(loop_opt.expr_linear_loops):
+                if system.initialized and flatten(loop_opt.expr_linear_loops):
                     vect = LoopVectorizer(loop_opt, kernel)
                     if align_pad:
                         # Padding and data alignment
                         vect.autovectorize()
                     if v_type and v_type != VectStrategy.AUTO:
-                        if isa['inst_set'] == 'SSE':
-                            raise RuntimeError("SSE vectorization not supported")
                         # Specialize vectorization for the memory access pattern
                         # of the expression
                         vect.specialize(v_type, v_param)
@@ -133,8 +126,6 @@ class ASTKernel(object):
             kernel.pred = [q for q in kernel.pred if q not in ['static', 'inline']]
             kernel.pred.insert(0, 'inline')
             kernel.pred.insert(0, 'static')
-
-            return loop_opts
 
         start_time = time.time()
 
@@ -264,113 +255,3 @@ class ASTKernel(object):
     def gencode(self):
         """Generate a string representation of the AST."""
         return self.ast.gencode()
-
-
-def init_coffee(_isa, _compiler, _arch='default'):
-    """Initialize COFFEE."""
-
-    global arch, isa, compiler, initialized
-
-    # Populate dictionaries with keywords for backend-specific (hardware,
-    # compiler, ...) optimizations
-    arch = _init_arch(_arch)
-    isa = _init_isa(_isa)
-    compiler = _init_compiler(_compiler)
-    if isa and compiler:
-        initialized = True
-
-    # Allow visits of ASTs that become huge due to transformation. The constant
-    # /4000/ was empirically found to be an acceptable value
-    sys.setrecursionlimit(4000)
-
-
-def _init_arch(arch):
-    """Set architecture-specific parameters."""
-
-    # In the following, all sizes are in Bytes
-    if arch == 'default':
-        # The default architecture is a conventional multi-core CPU, such as
-        # an Intel Haswell
-        return {
-            'cache_size': 256 * 10**3,  # The private, closest memory to the core
-            'double': 8
-        }
-
-    else:
-        return {
-            'cache_size': 0,
-            'double': sys.maxint
-        }
-
-
-def _init_isa(isa):
-    """Set the instruction set architecture (isa)."""
-
-    if isa == 'sse':
-        return {
-            'inst_set': 'SSE',
-            'avail_reg': 16,
-            'alignment': 16,
-            'dp_reg': 2,  # Number of double values per register
-            'reg': lambda n: 'xmm%s' % n
-        }
-
-    if isa == 'avx':
-        return {
-            'inst_set': 'AVX',
-            'avail_reg': 16,
-            'alignment': 32,
-            'dp_reg': 4,  # Number of double values per register
-            'reg': lambda n: 'ymm%s' % n,
-            'zeroall': '_mm256_zeroall ()',
-            'setzero': AVXSetZero(),
-            'decl_var': '__m256d',
-            'align_array': lambda p: '__attribute__((aligned(%s)))' % p,
-            'symbol_load': lambda s, r, o=None: AVXLoad(s, r, o),
-            'symbol_set': lambda s, r, o=None: AVXSet(s, r, o),
-            'store': lambda m, r: AVXStore(m, r),
-            'mul': lambda r1, r2: AVXProd(r1, r2),
-            'div': lambda r1, r2: AVXDiv(r1, r2),
-            'add': lambda r1, r2: AVXSum(r1, r2),
-            'sub': lambda r1, r2: AVXSub(r1, r2),
-            'l_perm': lambda r, f: AVXLocalPermute(r, f),
-            'g_perm': lambda r1, r2, f: AVXGlobalPermute(r1, r2, f),
-            'unpck_hi': lambda r1, r2: AVXUnpackHi(r1, r2),
-            'unpck_lo': lambda r1, r2: AVXUnpackLo(r1, r2)
-        }
-
-    return {}
-
-
-def _init_compiler(compiler):
-    """Set compiler-specific keywords. """
-
-    if compiler == 'intel':
-        return {
-            'name': 'intel',
-            'cmd': 'icc',
-            'align': lambda o: '__attribute__((aligned(%s)))' % o,
-            'align_forloop': '#pragma vector aligned',
-            'force_simdization': '#pragma simd',
-            'AVX': '-xAVX',
-            'SSE': '-xSSE',
-            'ipo': '-ip',
-            'native_opt': '-xHost',
-            'vect_header': '#include <immintrin.h>'
-        }
-
-    if compiler == 'gnu':
-        return {
-            'name': 'gnu',
-            'cmd': 'gcc',
-            'align': lambda o: '__attribute__((aligned(%s)))' % o,
-            'align_forloop': '',
-            'force_simdization': '',
-            'AVX': '-mavx',
-            'SSE': '-msse',
-            'ipo': '',
-            'native_opt': '-mtune=native',
-            'vect_header': '#include <immintrin.h>'
-        }
-
-    return {}

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -40,7 +40,7 @@ from coffee.visitors import *
 from hoister import Hoister
 from expander import Expander
 from factorizer import Factorizer
-from logger import Logger
+from logger import warn
 
 
 class ExpressionRewriter(object):
@@ -189,7 +189,7 @@ class ExpressionRewriter(object):
                 should_expand = lambda n: lda.get(n.symbol) and \
                     not lda[n.symbol].issubset(set(self.expr_info.linear_dims))
         else:
-            Logger.out('Skipping unknown expansion strategy.', 'func_warning')
+            warn('Skipping unknown expansion strategy.')
             return
 
         self.expr_expander.expand(should_expand, **kwargs)
@@ -280,7 +280,7 @@ class ExpressionRewriter(object):
             elif mode == 'constants':
                 should_factorize = lambda n: not lda.get(n.symbol)
         else:
-            Logger.out('Skipping unknown factorization strategy.', 'func_warning')
+            warn('Skipping unknown factorization strategy.')
             return
 
         # Perform the factorization
@@ -324,7 +324,7 @@ class ExpressionRewriter(object):
                 parent.children[parent.children.index(node)] = reassociated_node
 
             else:
-                Logger.out('Unexpected node %s' % typ(node), 'func_warning')
+                warn('Unexpected node %s while reassociating' % typ(node))
 
         reorder = reorder if reorder else lambda n: (n.rank, n.dim)
         _reassociate(self.stmt.rvalue, self.stmt)

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -32,7 +32,6 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from collections import Counter
-from warnings import warn as warning
 import pulp as ilp
 
 from base import *
@@ -41,6 +40,7 @@ from coffee.visitors import *
 from hoister import Hoister
 from expander import Expander
 from factorizer import Factorizer
+from logger import Logger
 
 
 class ExpressionRewriter(object):
@@ -189,7 +189,7 @@ class ExpressionRewriter(object):
                 should_expand = lambda n: lda.get(n.symbol) and \
                     not lda[n.symbol].issubset(set(self.expr_info.linear_dims))
         else:
-            warning('Unknown expansion strategy. Skipping.')
+            Logger.out('Skipping unknown expansion strategy.', 'func_warning')
             return
 
         self.expr_expander.expand(should_expand, **kwargs)
@@ -280,7 +280,7 @@ class ExpressionRewriter(object):
             elif mode == 'constants':
                 should_factorize = lambda n: not lda.get(n.symbol)
         else:
-            warning('Unknown factorization strategy. Skipping.')
+            Logger.out('Skipping unknown factorization strategy.', 'func_warning')
             return
 
         # Perform the factorization
@@ -324,7 +324,7 @@ class ExpressionRewriter(object):
                 parent.children[parent.children.index(node)] = reassociated_node
 
             else:
-                warning('Unexpect node of type %s while reassociating', typ(node))
+                Logger.out('Unexpected node %s' % typ(node), 'func_warning')
 
         reorder = reorder if reorder else lambda n: (n.rank, n.dim)
         _reassociate(self.stmt.rvalue, self.stmt)

--- a/coffee/system.py
+++ b/coffee/system.py
@@ -36,7 +36,7 @@
 import sys
 
 from base import *
-from logger import Logger
+from logger import LOG_DEFAULT, set_log_level
 
 
 __all__ = ['arch', 'compiler', 'isa', 'options', 'initialized']
@@ -85,7 +85,7 @@ def coffee_init(**kwargs):
     if all([architecture, compiler, isa]):
         initialized = True
 
-    options.register('logging', Logger.current(), Logger.set_level)
+    options.register('logging', LOG_DEFAULT, set_log_level)
     options.register('architecture', architecture_id, set_architecture)
     options.register('compiler', compiler_id, set_compiler)
     options.register('isa', isa_id, set_isa)

--- a/coffee/system.py
+++ b/coffee/system.py
@@ -36,6 +36,7 @@
 import sys
 
 from base import *
+from logger import Logger
 
 
 __all__ = ['arch', 'compiler', 'isa', 'options', 'initialized']
@@ -84,7 +85,7 @@ def coffee_init(**kwargs):
     if all([architecture, compiler, isa]):
         initialized = True
 
-    options['verbose'] = True
+    options.register('logging', Logger.current(), Logger.set_level)
     options.register('architecture', architecture_id, set_architecture)
     options.register('compiler', compiler_id, set_compiler)
     options.register('isa', isa_id, set_isa)
@@ -191,3 +192,13 @@ def set_isa(isa_id):
         }
 
     return {}
+
+
+def set_min_log_level():
+    """Minimize logging output."""
+    global options
+    options['logging'] = 'func_warning'
+
+
+def set_max_log_level():
+    """Maximize logging output."""

--- a/coffee/system.py
+++ b/coffee/system.py
@@ -1,0 +1,193 @@
+# This file is part of COFFEE
+#
+# COFFEE is Copyright (c) 2016, Imperial College London.
+# Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Provide mechanisms to initialize COFFEE or change its state."""
+
+import sys
+
+from base import *
+
+
+__all__ = ['arch', 'compiler', 'isa', 'options', 'initialized']
+
+
+class Options(dict):
+
+    def __init__(self):
+        self._callbacks = {}
+
+    def __setitem__(self, key, value):
+        super(Options, self).__setitem__(key, value)
+        self.maybe_update_backend(key, value)
+
+    def register(self, key, value=None, callback=None):
+        self[key] = value
+        if callback:
+            self._callbacks[key] = callback
+
+    def maybe_update_backend(self, key, value):
+        if key in self._callbacks:
+            self._callbacks[key](value)
+
+
+initialized = False
+options = Options()
+
+architecture = {}
+compiler = {}
+isa = {}  # Instruction Set Architecture
+
+
+def coffee_init(**kwargs):
+    """Initialize COFFEE."""
+
+    global initialized, options, architecture, compiler, isa
+
+    architecture_id = kwargs.get('architecture', 'default')
+    compiler_id = kwargs.get('compiler')
+    isa_id = kwargs.get('isa')
+
+    architecture = set_architecture(architecture_id)
+    compiler = set_compiler(compiler_id)
+    isa = set_isa(isa_id)
+
+    if all([architecture, compiler, isa]):
+        initialized = True
+
+    options['verbose'] = True
+    options.register('architecture', architecture_id, set_architecture)
+    options.register('compiler', compiler_id, set_compiler)
+    options.register('isa', isa_id, set_isa)
+
+    # Allow visits of ASTs that become huge due to transformation. The constant
+    # /4000/ was empirically found to be an acceptable value
+    sys.setrecursionlimit(4000)
+
+
+def set_architecture(architecture_id):
+    """Set architecture-specific parameters. Supported architectures:
+
+        * 'default'/'intel': a conventional multi-core CPU, such as an Intel Haswell
+    """
+
+    # All sizes are in Bytes
+    # The /cache_size/ is the size of the private memory closest to a core
+
+    if architecture_id in ['default', 'intel']:
+        return {
+            'cache_size': 256 * 10**3,
+            'double': 8
+        }
+
+    return {}
+
+
+def set_compiler(compiler_id):
+    """Set compiler-specific keywords. Supported compilers:
+
+        * 'gnu' (aka gcc)
+        * 'intel' (aka icc)
+    """
+
+    if compiler == 'gnu':
+        return {
+            'name': 'gnu',
+            'cmd': 'gcc',
+            'align': lambda o: '__attribute__((aligned(%s)))' % o,
+            'align_forloop': '',
+            'force_simdization': '',
+            'AVX': '-mavx',
+            'SSE': '-msse',
+            'ipo': '',
+            'native_opt': '-mtune=native',
+            'vect_header': '#include <immintrin.h>'
+        }
+
+    if compiler == 'intel':
+        return {
+            'name': 'intel',
+            'cmd': 'icc',
+            'align': lambda o: '__attribute__((aligned(%s)))' % o,
+            'align_forloop': '#pragma vector aligned',
+            'force_simdization': '#pragma simd',
+            'AVX': '-xAVX',
+            'SSE': '-xSSE',
+            'ipo': '-ip',
+            'native_opt': '-xHost',
+            'vect_header': '#include <immintrin.h>'
+        }
+
+    return {}
+
+
+def set_isa(isa_id):
+    """Set the instruction set architecture (ISA). Supported ISAs:
+
+        * 'sse'
+        * 'avx'
+    """
+
+    if isa == 'sse':
+        return {
+            'inst_set': 'SSE',
+            'avail_reg': 16,
+            'alignment': 16,
+            'dp_reg': 2,  # Number of values in double precision per register
+            'reg': lambda n: 'xmm%s' % n
+        }
+
+    if isa == 'avx':
+        return {
+            'inst_set': 'AVX',
+            'avail_reg': 16,
+            'alignment': 32,
+            'dp_reg': 4,  # Number of values in double precision per register
+            'reg': lambda n: 'ymm%s' % n,
+            'zeroall': '_mm256_zeroall ()',
+            'setzero': AVXSetZero(),
+            'decl_var': '__m256d',
+            'align_array': lambda p: '__attribute__((aligned(%s)))' % p,
+            'symbol_load': lambda s, r, o=None: AVXLoad(s, r, o),
+            'symbol_set': lambda s, r, o=None: AVXSet(s, r, o),
+            'store': lambda m, r: AVXStore(m, r),
+            'mul': lambda r1, r2: AVXProd(r1, r2),
+            'div': lambda r1, r2: AVXDiv(r1, r2),
+            'add': lambda r1, r2: AVXSum(r1, r2),
+            'sub': lambda r1, r2: AVXSub(r1, r2),
+            'l_perm': lambda r, f: AVXLocalPermute(r, f),
+            'g_perm': lambda r1, r2, f: AVXGlobalPermute(r1, r2, f),
+            'unpck_hi': lambda r1, r2: AVXUnpackHi(r1, r2),
+            'unpck_lo': lambda r1, r2: AVXUnpackLo(r1, r2)
+        }
+
+    return {}

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -35,7 +35,6 @@
 
 from copy import deepcopy as dcopy
 from collections import defaultdict, OrderedDict
-import sys
 
 import networkx as nx
 
@@ -882,17 +881,3 @@ def postprocess(node):
 
     _postprocess(node, None)
     make_blocks()
-
-
-# Colors if the terminal supports it (disabled e.g. when piped to file)
-# This code is partly extracted from ``https://bitbucket.org/fenics-project/ufl``
-if sys.stdout.isatty() and sys.stderr.isatty():
-    RED = "\033[1;37;31m%s\033[0m"
-    BLUE = "\033[1;37;34m%s\033[0m"
-    GREEN = "\033[1;37;32m%s\033[0m"
-    HEADER = "\033[95m%s\033[0m"
-else:
-    RED = "%s"
-    BLUE = "%s"
-    GREEN = "%s"
-    HEADER = "%s"

--- a/coffee/vectorizer.py
+++ b/coffee/vectorizer.py
@@ -35,11 +35,12 @@ from math import ceil
 from copy import deepcopy as dcopy
 from collections import OrderedDict
 from itertools import product
+from warnings import warn as warning
 import numpy
 
 from base import *
 from utils import *
-import plan
+import system
 from coffee.visitors import FindInstances
 
 
@@ -165,7 +166,7 @@ class LoopVectorizer(object):
         symbol_refs = info['symbol_refs']
         retval = FindInstances.default_retval()
         to_invert = FindInstances(Invert).visit(self.header, ret=retval)[Invert]
-        align = plan.compiler['align'](plan.isa['alignment'])
+        align = system.compiler['align'](system.isa['alignment'])
 
         buffer = None
         for decl_name, decl in self.decls.items():
@@ -296,7 +297,7 @@ class LoopVectorizer(object):
             checks ensure the correctness of the transformation.
             * Decorate declarations with qualifiers for data alignment
         """
-        vector_length = plan.isa["dp_reg"]
+        vector_length = system.isa["dp_reg"]
 
         for l in inner_loops(self.header):
             should_round, should_vectorize = True, True
@@ -440,10 +441,10 @@ class LoopVectorizer(object):
                                 self.nz_syms[r.symbol][i][:p_dim] + \
                                 ((size, offset-(orig_ofs-start)),)
                 if l.start % vector_length == 0 and l.size % vector_length == 0:
-                    l.pragma.add(plan.compiler["align_forloop"])
+                    l.pragma.add(system.compiler["align_forloop"])
             # Enforce vectorization if loop size is a multiple of the vector length
             if should_vectorize and l.size % vector_length == 0:
-                l.pragma.add(plan.compiler['force_simdization'])
+                l.pragma.add(system.compiler['force_simdization'])
 
     def _transpose_layout(self):
         dim = self.loop.dim
@@ -483,6 +484,13 @@ class LoopVectorizer(object):
         The parameter ``opts`` can be used to drive the transformation process by
         specifying one of the vectorization strategies in :class:`VectStrategy`.
         """
+        vs = VectStrategy
+        if opts not in [vs.SPEC_UAJ_PADD, vs.SPEC_UAJ_PADD_FULL,
+                        vs.SPEC_PADD, vs.SPEC_PEEL]:
+            warning("Don't know how to vectorize option %s, giving up." % opts)
+        if system.isa['inst_set'] == 'SSE':
+            warning("Don't know how to specialize vectorization for SSE")
+
         layout = None
         for stmt, expr_info in self.exprs.items():
             if expr_info.dimension != 2:
@@ -492,7 +500,7 @@ class LoopVectorizer(object):
             linear_loops_parents = expr_info.linear_loops_parents
 
             # Check if outer-product vectorization is actually doable
-            vect_len = plan.isa["dp_reg"]
+            vect_len = system.isa["dp_reg"]
             rows = linear_loops[0].size
             if rows < vect_len:
                 continue
@@ -500,7 +508,6 @@ class LoopVectorizer(object):
             op = OuterProduct(stmt, linear_loops, 'STORE')
 
             # Vectorisation
-            vs = VectStrategy
             unroll_factor = factor if opts in [vs.SPEC_UAJ_PADD, vs.SPEC_UAJ_PADD_FULL] else 1
             rows_per_it = vect_len*unroll_factor
             if opts == vs.SPEC_UAJ_PADD:
@@ -517,8 +524,6 @@ class LoopVectorizer(object):
                     body, layout = op.generate(rows_per_it)
             elif opts in [vs.SPEC_PADD, vs.SPEC_PEEL]:
                 body, layout = op.generate(vect_len)
-            else:
-                raise RuntimeError("Don't know how to vectorize option %s" % opts)
 
             # Construct the remainder loop
             if opts != vs.SPEC_UAJ_PADD_FULL and rows > rows_per_it and rows % rows_per_it > 0:
@@ -558,11 +563,11 @@ class OuterProduct(object):
         """Handle allocation of register variables. """
 
         def __init__(self, tensor_size):
-            nres = max(plan.isa["dp_reg"], tensor_size)
-            self.ntot = plan.isa["avail_reg"]
-            self.res = [plan.isa["reg"](v) for v in range(nres)]
-            self.var = [plan.isa["reg"](v) for v in range(nres, self.ntot)]
-            self.i = plan.isa
+            nres = max(system.isa["dp_reg"], tensor_size)
+            self.ntot = system.isa["avail_reg"]
+            self.res = [system.isa["reg"](v) for v in range(nres)]
+            self.var = [system.isa["reg"](v) for v in range(nres, self.ntot)]
+            self.i = system.isa
 
         def get_reg(self):
             if len(self.var) == 0:
@@ -586,9 +591,9 @@ class OuterProduct(object):
                 if node.rank and node.rank[-1] == self.loops[1].dim]
 
         if step in [0, 2]:
-            return [Assign(r, plan.isa["l_perm"](r, "5")) for r in regs]
+            return [Assign(r, system.isa["l_perm"](r, "5")) for r in regs]
         elif step == 1:
-            return [Assign(r, plan.isa["g_perm"](r, r, "1")) for r in regs]
+            return [Assign(r, system.isa["g_perm"](r, r, "1")) for r in regs]
         elif step == 3:
             return []
 
@@ -606,12 +611,12 @@ class OuterProduct(object):
         stmt = []
         for node, reg in vrs.items():
             if node.rank and node.rank[-1] in [l.dim for l in self.loops]:
-                exp = plan.isa["symbol_load"](node.symbol, node.rank, node.offset)
+                exp = system.isa["symbol_load"](node.symbol, node.rank, node.offset)
             else:
-                exp = plan.isa["symbol_set"](node.symbol, node.rank, node.offset)
+                exp = system.isa["symbol_set"](node.symbol, node.rank, node.offset)
             if not decls.get(node.gencode()):
                 decls[node.gencode()] = reg
-                stmt.append(Decl(plan.isa["decl_var"], reg, exp))
+                stmt.append(Decl(system.isa["decl_var"], reg, exp))
         return stmt
 
     def _vect_expr(self, node, ofs, regs, decls, vrs):
@@ -645,13 +650,13 @@ class OuterProduct(object):
             left = self._vect_expr(node.left, ofs, regs, decls, vrs)
             right = self._vect_expr(node.right, ofs, regs, decls, vrs)
             if isinstance(node, Sum):
-                return plan.isa["add"](left, right)
+                return system.isa["add"](left, right)
             elif isinstance(node, Sub):
-                return plan.isa["sub"](left, right)
+                return system.isa["sub"](left, right)
             elif isinstance(node, Prod):
-                return plan.isa["mul"](left, right)
+                return system.isa["mul"](left, right)
             elif isinstance(node, Div):
-                return plan.isa["div"](left, right)
+                return system.isa["div"](left, right)
 
     def _incr_tensor(self, tensor, ofs, regs, out_reg):
         """Add the right hand side contained in out_reg to tensor.
@@ -667,13 +672,13 @@ class OuterProduct(object):
             sym = tensor.symbol
             rank = tensor.rank
             ofs = tensor.offset[:-2] + ((1, ofs),) + tensor.offset[-1:]
-            load = plan.isa["symbol_load"](sym, rank, ofs)
-            return plan.isa["store"](Symbol(sym, rank, ofs),
-                                     plan.isa["add"](load, out_reg))
+            load = system.isa["symbol_load"](sym, rank, ofs)
+            return system.isa["store"](Symbol(sym, rank, ofs),
+                                       system.isa["add"](load, out_reg))
         elif self.mode == 'MOVE':
             # Accumulate on a vector register
             reg = Symbol(regs.get_tensor()[ofs], ())
-            return Assign(reg, plan.isa["add"](reg, out_reg))
+            return Assign(reg, system.isa["add"](reg, out_reg))
 
     def _restore_layout(self, regs, tensor):
         """Restore the storage layout of the tensor.
@@ -694,15 +699,15 @@ class OuterProduct(object):
         # Load LHS values from memory
         if self.mode == 'STORE':
             for i, j in zip(tensor_syms, t_regs):
-                load_sym = plan.isa["symbol_load"](i.symbol, i.rank, i.offset)
-                code.append(Decl(plan.isa["decl_var"], j, load_sym))
+                load_sym = system.isa["symbol_load"](i.symbol, i.rank, i.offset)
+                code.append(Decl(system.isa["decl_var"], j, load_sym))
 
         # In-register restoration of the tensor layout
-        perm = plan.isa["g_perm"]
-        uphi = plan.isa["unpck_hi"]
-        uplo = plan.isa["unpck_lo"]
-        typ = plan.isa["decl_var"]
-        vect_len = plan.isa["dp_reg"]
+        perm = system.isa["g_perm"]
+        uphi = system.isa["unpck_hi"]
+        uplo = system.isa["unpck_lo"]
+        typ = system.isa["decl_var"]
+        vect_len = system.isa["dp_reg"]
         # Do as many times as the unroll factor
         spins = int(ceil(n_regs / float(vect_len)))
         for i in range(spins):
@@ -721,7 +726,7 @@ class OuterProduct(object):
             # Store LHS values in memory
             for j in range(min(vect_len, n_regs - i * vect_len)):
                 ofs = i * vect_len + j
-                code.append(plan.isa["store"](tensor_syms[ofs], t_regs[ofs]))
+                code.append(system.isa["store"](tensor_syms[ofs], t_regs[ofs]))
 
         return code
 
@@ -747,7 +752,7 @@ class OuterProduct(object):
         loops are very small *and* a suitable permutation of the nest has been
         chosen to minimize register spilling.
         """
-        cols = plan.isa["dp_reg"]
+        cols = system.isa["dp_reg"]
         tensor, expr = self.stmt.children
         tensor_size = cols
 
@@ -792,7 +797,7 @@ class OuterProduct(object):
         elif self.mode == 'MOVE':
             # Initialiser
             for r in regs.get_tensor():
-                decl = Decl(plan.isa["decl_var"], Symbol(r, ()), plan.isa["setzero"])
+                decl = Decl(system.isa["decl_var"], Symbol(r, ()), system.isa["setzero"])
                 self.loops[1].body.insert(0, decl)
             # Tensor layout
             self.loops[1].body.extend(layout)
@@ -805,11 +810,11 @@ class OuterProduct(object):
 
 def vect_roundup(x):
     """Return x rounded up to the vector length. """
-    word_len = plan.isa.get("dp_reg") or 1
+    word_len = system.isa.get("dp_reg") or 1
     return int(ceil(x / float(word_len))) * word_len
 
 
 def vect_rounddown(x):
     """Return x rounded down to the vector length. """
-    word_len = plan.isa.get("dp_reg") or 1
+    word_len = system.isa.get("dp_reg") or 1
     return x - (x % word_len)

--- a/coffee/vectorizer.py
+++ b/coffee/vectorizer.py
@@ -40,7 +40,7 @@ import numpy
 from base import *
 from utils import *
 import system
-from logger import Logger
+from logger import warn
 from coffee.visitors import FindInstances
 
 
@@ -487,9 +487,9 @@ class LoopVectorizer(object):
         vs = VectStrategy
         if opts not in [vs.SPEC_UAJ_PADD, vs.SPEC_UAJ_PADD_FULL,
                         vs.SPEC_PADD, vs.SPEC_PEEL]:
-            Logger.out("Don't know how to vectorize %s" % opts, "func_warning")
+            warn("Don't know how to specialize vectorization for %s" % opts)
         if system.isa['inst_set'] == 'SSE':
-            Logger.out("Don't know how to specialize vectorization for SSE", "func_warning")
+            warn("Don't know how to specialize vectorization for SSE")
 
         layout = None
         for stmt, expr_info in self.exprs.items():

--- a/coffee/vectorizer.py
+++ b/coffee/vectorizer.py
@@ -35,12 +35,12 @@ from math import ceil
 from copy import deepcopy as dcopy
 from collections import OrderedDict
 from itertools import product
-from warnings import warn as warning
 import numpy
 
 from base import *
 from utils import *
 import system
+from logger import Logger
 from coffee.visitors import FindInstances
 
 
@@ -487,9 +487,9 @@ class LoopVectorizer(object):
         vs = VectStrategy
         if opts not in [vs.SPEC_UAJ_PADD, vs.SPEC_UAJ_PADD_FULL,
                         vs.SPEC_PADD, vs.SPEC_PEEL]:
-            warning("Don't know how to vectorize option %s, giving up." % opts)
+            Logger.out("Don't know how to vectorize %s" % opts, "func_warning")
         if system.isa['inst_set'] == 'SSE':
-            warning("Don't know how to specialize vectorization for SSE")
+            Logger.out("Don't know how to specialize vectorization for SSE", "func_warning")
 
         layout = None
         for stmt, expr_info in self.exprs.items():


### PR DESCRIPTION
Straightforward refactoring.

1- Move stuff from plan.py which are not really part of the plan to a different module (system.py)
2- Logging now occurs through a separate module. It's a very basic logging infrastructure, which we might even drop once we centralise the one currently used in PyOP2. But it works for now.

Overall, the quality of the codebase improves

Because of point 1 above, this PR depends on PR 490 in PyOP2