### PR TITLE
Split coffee.system and switch to absolute imports

### DIFF
--- a/coffee/__init__.py
+++ b/coffee/__init__.py
@@ -1,0 +1,182 @@
+# This file is part of COFFEE
+#
+# COFFEE is Copyright (c) 2016, Imperial College London.
+# Please see the AUTHORS file in the main source directory for
+# a full list of copyright holders.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#     * The name of Imperial College London or that of other
+#       contributors may not be used to endorse or promote products
+#       derived from this software without specific prior written
+#       permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTERS
+# ''AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import absolute_import
+
+import sys
+
+from coffee.citations import update_citations
+from coffee.vectorizer import VectStrategy
+from coffee.logger import LOG_DEFAULT, set_log_level, warn
+from coffee.system import set_architecture, set_compiler, set_isa
+
+
+__all__ = ['options', 'initialized', 'O0', 'O1', 'O2', 'O3', 'Ofast']
+
+
+class Options(dict):
+
+    def __init__(self):
+        self._callbacks = {}
+
+    def __setitem__(self, key, value):
+        super(Options, self).__setitem__(key, value)
+        self.maybe_update_backend(key, value)
+
+    def register(self, key, value=None, callback=None):
+        self[key] = value
+        if callback:
+            self._callbacks[key] = callback
+
+    def maybe_update_backend(self, key, value):
+        if key in self._callbacks:
+            self._callbacks[key](value)
+
+
+class OptimizationLevel(dict):
+
+    _KNOWN = {}
+
+    @classmethod
+    def retrieve(cls, optlevel):
+        """Retrieve the set of transformations corresponding to ``optlevel``.
+
+        :param optlevel: may be an :class:`OptimizationLevel` itself (in which
+        case ``optlevel`` itself is returned) or the name of the level (a string).
+        """
+        if isinstance(optlevel, OptimizationLevel):
+            return optlevel
+        elif isinstance(optlevel, str) and optlevel in cls._KNOWN:
+            return cls._KNOWN[optlevel]
+        elif not optlevel:
+            return O0
+        else:
+            warn("Unrecognized optimization specified.")
+            return O0
+
+    def __init__(self, name, **kwargs):
+        self.name = name
+
+        for key, value in kwargs.iteritems():
+            self[key] = value
+
+        OptimizationLevel._KNOWN[name] = self
+
+
+def coffee_init(**kwargs):
+    """Initialize COFFEE.
+
+    :param compiler: Options: ``gnu``, ``intel``. By knowing the backend compiler,
+        COFFEE can generate specialized code (e.g., by inserting suitable loop pragmas).
+    :param isa: Options: ``sse``, ``avx``. The instruction set architecture tells
+        COFFEE the vector length and the available intrinsics so that optimized
+        vector code (or scalar code suitable for compiler auto-vectorization) is
+        generated.
+    :param architecture: Options: ``default``, ``intel``.
+    :param optlevel: Options: ``O0`` (default), ``O1``, ``O2``, ``O3``, ``Ofast``.
+        The higher the optimization level, the more aggresively are the transformations.
+        For more details, refer to the ``set_opt_level``'s documentation.
+    """
+
+    global initialized, options, architecture, compiler, isa
+
+    architecture_id = kwargs.get('architecture', 'default')
+    compiler_id = kwargs.get('compiler')
+    isa_id = kwargs.get('isa')
+    optlevel = kwargs.get('optlevel', O0)
+
+    architecture = set_architecture(architecture_id)
+    compiler = set_compiler(compiler_id)
+    isa = set_isa(isa_id)
+
+    if all([architecture, compiler, isa]):
+        initialized = True
+
+    options['architecture'] = architecture_id
+    options['compiler'] = compiler_id
+    options['isa'] = isa_id
+    options['optimizations'] = optlevel
+
+    # Allow visits of ASTs that become huge due to transformation. The constant
+    # /4000/ was empirically found to be an acceptable value
+    sys.setrecursionlimit(4000)
+
+
+def coffee_reconfigure(**kwargs):
+    """Reconfigure the internal state of COFFEE."""
+
+    options['optimizations'] = kwargs.get('optlevel')
+
+
+def set_opt_level(optlevel):
+    """Set the default optimization level.
+
+    :param optlevel: accepted values are: ::
+
+        ``O0``: No optimizations are applied at all (default).
+        ``O1``: Apply generalized loop-invariant code motion. Refer to
+            ``citations.LUPORINI2015`` for more information.
+        ``O2``: Apply sharing elimination and elimination of useless floating
+            point operations (e.g., a + 0 == a). Refer to ``citations.LUPORINI2016``
+            for more information.
+        ``O3``: Apply ``O2`` and enforce data alignment through array padding.
+            This maximizes the impact of compiler auto-vectorization, as thoroughly
+            discussed in ``citations.LUPORINI2015``.
+        ``Ofast``: Apply ``O3``, but resort to explicit outer-product vectorization
+            instead. Vector promotion is also attempted to maximize vectorization in
+            the outer loops. Refer to ``citations.LUPORINI2015`` for more information.
+
+        Alternatively, one can craft a new composite transformation by creating a
+        new :class:`OptimizationLevel`.
+    """
+
+    optimizations = OptimizationLevel.retrieve(optlevel)
+
+    update_citations(optimizations)
+
+
+O0 = OptimizationLevel('O0')
+O1 = OptimizationLevel('O1', rewrite=1)
+O2 = OptimizationLevel('O2', rewrite=2, dead_ops_elimination=True)
+O3 = OptimizationLevel('O3', align_pad=True, **O2)
+Ofast = OptimizationLevel('Ofast', vectorize=(VectStrategy.SPEC_UAJ_PADD, 2),
+                          precompute='noloops', **O3)
+
+initialized = False
+
+options = Options()
+options.register('logging', LOG_DEFAULT, set_log_level)
+options.register('architecture', callback=set_architecture)
+options.register('compiler', callback=set_compiler)
+options.register('isa', callback=set_isa)
+options.register('optimizations', O0.name, callback=set_opt_level)

--- a/coffee/base.py
+++ b/coffee/base.py
@@ -33,6 +33,7 @@
 
 """This file contains the hierarchy of classes that implement a kernel's
 Abstract Syntax Tree (AST)."""
+from __future__ import absolute_import
 
 from copy import deepcopy as dcopy
 from math import isnan
@@ -461,12 +462,12 @@ class Symbol(Expr):
 
     @property
     def is_const(self):
-        from utils import is_const_dim
+        from .utils import is_const_dim
         return not self.rank or all(is_const_dim(r) for r in self.rank)
 
     @property
     def is_const_offset(self):
-        from utils import is_const_dim, flatten
+        from .utils import is_const_dim, flatten
         return not self.offset or all(is_const_dim(o) for o in flatten(self.offset))
 
     @property

--- a/coffee/cse.py
+++ b/coffee/cse.py
@@ -31,14 +31,17 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from sys import maxint
+from __future__ import absolute_import
+
+from sys import maxsize
 import operator
 
-from base import *
-from utils import *
+from .base import *
+from .utils import *
 from coffee.visitors import EstimateFlops
-from expression import MetaExpr
-from logger import log, COST_MODEL
+from .expression import MetaExpr
+from .logger import log, COST_MODEL
+from functools import reduce
 
 
 class Temporary(object):
@@ -231,7 +234,7 @@ class CSEUnpicker(object):
                         t.linear_reads_costs[p] = c + p_c
 
     def _transform_temporaries(self, temporaries):
-        from rewriter import ExpressionRewriter
+        from .rewriter import ExpressionRewriter
 
         # Never attempt to transform the main expression
         temporaries = [t for t in temporaries if t.node not in self.exprs]
@@ -343,9 +346,9 @@ class CSEUnpicker(object):
         for s, t in trace.items():
             new_trace[s] = t.reconstruct()
 
-        best = (bounds[0], bounds[0], maxint)
+        best = (bounds[0], bounds[0], maxsize)
         fact_levels = {k: v for k, v in levels.items() if k > bounds[0] and k <= bounds[1]}
-        for level, temporaries in sorted(fact_levels.items(), key=lambda (i, j): i):
+        for level, temporaries in sorted(fact_levels.items(), key=lambda i_j: i_j[0]):
             level_inloop_cost = 0
             for t in temporaries:
                 # The operation count, after fact+licm, outside /loop/, induced by /t/

--- a/coffee/expander.py
+++ b/coffee/expander.py
@@ -31,11 +31,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 import itertools
 
-from base import *
-from utils import *
-from exceptions import UnexpectedNode
+from .base import *
+from .utils import *
+from .exceptions import UnexpectedNode
 
 
 class Expander(object):

--- a/coffee/expression.py
+++ b/coffee/expression.py
@@ -31,7 +31,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from utils import *
+from __future__ import absolute_import
+
+from .utils import *
 from collections import OrderedDict
 
 

--- a/coffee/factorizer.py
+++ b/coffee/factorizer.py
@@ -31,10 +31,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 import operator
 
-from base import *
-from utils import *
+from .base import *
+from .utils import *
+from functools import reduce
 
 
 class Term(object):

--- a/coffee/hoister.py
+++ b/coffee/hoister.py
@@ -31,9 +31,11 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from base import *
-from utils import *
-from logger import warn
+from __future__ import absolute_import
+
+from .base import *
+from .utils import *
+from .logger import warn
 
 
 class Extractor(object):

--- a/coffee/optimizer.py
+++ b/coffee/optimizer.py
@@ -31,20 +31,23 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 import operator
 import resource
 from collections import OrderedDict
 from itertools import combinations
 from math import factorial as fact
 
-import system
-from base import *
-from utils import *
-from scheduler import ExpressionFissioner, ZeroRemover, SSALoopMerger
-from rewriter import ExpressionRewriter
-from cse import CSEUnpicker
-from logger import warn
+from . import system
+from .base import *
+from .utils import *
+from .scheduler import ExpressionFissioner, ZeroRemover, SSALoopMerger
+from .rewriter import ExpressionRewriter
+from .cse import CSEUnpicker
+from .logger import warn
 from coffee.visitors import FindInstances, ProjectExpansion
+from functools import reduce
 
 
 class LoopOptimizer(object):

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -32,14 +32,15 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """COFFEE's optimization plan constructor."""
+from __future__ import absolute_import
 
-import system
-from base import *
-from utils import *
-from optimizer import CPULoopOptimizer, GPULoopOptimizer
-from vectorizer import LoopVectorizer, VectStrategy
-from expression import MetaExpr
-from logger import log, warn, PERF_OK, PERF_WARN
+import coffee
+from .base import *
+from .utils import *
+from .optimizer import CPULoopOptimizer, GPULoopOptimizer
+from .vectorizer import LoopVectorizer, VectStrategy
+from .expression import MetaExpr
+from .logger import log, warn, PERF_OK, PERF_WARN
 from coffee.visitors import FindInstances, EstimateFlops
 
 from collections import defaultdict, OrderedDict
@@ -58,9 +59,9 @@ class ASTKernel(object):
         """Optimize this :class:`ASTKernel` for CPU execution.
 
         :param opts: a dictionary of optimizations to be applied. For a description
-            of the recognized optimizations, please refer to the ``system.set_opt_level``
+            of the recognized optimizations, please refer to the ``coffee.set_opt_level``
             documentation. If equal to ``None``, the default optimizations in
-            ``system.options['optimizations']`` are applied; these are either the
+            ``coffee.options['optimizations']`` are applied; these are either the
             optimizations set when COFFEE was initialized or those changed through
             a call to ``set_opt_level``. In this way, a default set of optimizations
             is applied to all kernels, but users are also allowed to select
@@ -73,9 +74,9 @@ class ASTKernel(object):
         kernels = finder.visit(self.ast, ret=FindInstances.default_retval())[FunDecl]
 
         if opts is None:
-            opts = system.OptimizationLevel.retrieve(system.options['optimizations'])
+            opts = coffee.OptimizationLevel.retrieve(coffee.options['optimizations'])
         else:
-            opts = system.OptimizationLevel.retrieve(opts.get('optlevel', {}))
+            opts = coffee.OptimizationLevel.retrieve(opts.get('optlevel', {}))
 
         flops_pre = EstimateFlops().visit(self.ast)
 
@@ -127,7 +128,7 @@ class ASTKernel(object):
                     loop_opt.split(split)
                 if precompute:
                     loop_opt.precompute(precompute)
-                if system.initialized and flatten(loop_opt.expr_linear_loops):
+                if coffee.initialized and flatten(loop_opt.expr_linear_loops):
                     vect = LoopVectorizer(loop_opt, kernel)
                     if align_pad:
                         # Padding and data alignment

--- a/coffee/rewriter.py
+++ b/coffee/rewriter.py
@@ -31,16 +31,18 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from collections import Counter
 import pulp as ilp
 
-from base import *
-from utils import *
+from .base import *
+from .utils import *
 from coffee.visitors import *
-from hoister import Hoister
-from expander import Expander
-from factorizer import Factorizer
-from logger import warn
+from .hoister import Hoister
+from .expander import Expander
+from .factorizer import Factorizer
+from .logger import warn
 
 
 class ExpressionRewriter(object):

--- a/coffee/scheduler.py
+++ b/coffee/scheduler.py
@@ -31,15 +31,17 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from collections import OrderedDict, defaultdict
 from itertools import product
 from copy import deepcopy as dcopy
 
-from base import *
-from utils import *
-from expression import copy_metaexpr
-from rewriter import ExpressionRewriter
-from exceptions import ControlFlowError, UnexpectedNode
+from .base import *
+from .utils import *
+from .expression import copy_metaexpr
+from .rewriter import ExpressionRewriter
+from .exceptions import ControlFlowError, UnexpectedNode
 from coffee.visitors import FindLoopNests
 
 

--- a/coffee/vectorizer.py
+++ b/coffee/vectorizer.py
@@ -31,15 +31,17 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import absolute_import
+
 from math import ceil
 from copy import deepcopy as dcopy
 from collections import OrderedDict, namedtuple
 from itertools import product
 
-from base import *
-from utils import *
-import system
-from logger import warn
+from .base import *
+from .utils import *
+from . import system
+from .logger import warn
 from coffee.visitors import FindInstances
 
 

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -2,6 +2,7 @@ import pytest
 from coffee.base import *
 from coffee.visitors import *
 from collections import Counter
+from functools import reduce
 
 
 @pytest.mark.parametrize("key",


### PR DESCRIPTION
Some of `coffee.system` is moved to `coffee.__init__`. That requires minor imports changes in Firedrake and PyOP2 (pull requests for them are coming soon).

Resolves #86.