### PR TITLE
Extending FunDecl to support template kernel functions

### DIFF
--- a/coffee/base.py
+++ b/coffee/base.py
@@ -969,25 +969,26 @@ class FunDecl(Statement):
 
     Syntax: ::
 
-        [pred] ret name ([args]) {body};
+        [template] [pred] ret name ([args]) {body};
 
     E.g.: ::
 
         static inline void foo(int a, int b) {return;};"""
 
-    def __init__(self, ret, name, args, body, pred=[], headers=None):
+    def __init__(self, ret, name, args, body, pred=[], headers=None, template=[]):
         super(FunDecl, self).__init__([enforce_block(body)])
         self.pred = pred
         self.ret = ret
         self.name = name
         self.args = args
         self.headers = headers or []
+        self.template = template
 
     def operands(self):
-        return [self.ret, self.name, self.args, self.children[0], self.pred, self.headers], {}
+        return [self.ret, self.name, self.args, self.children[0], self.pred, self.headers, self.template], {}
 
-    def reconstruct(self, ret, name, args, body, pred, headers, **kwargs):
-        return type(self)(ret, name, args, body, pred, headers, **kwargs)
+    def reconstruct(self, ret, name, args, body, pred, headers, template, **kwargs):
+        return type(self)(ret, name, args, body, pred, headers, template, **kwargs)
 
     @property
     def body(self):
@@ -1000,8 +1001,8 @@ class FunDecl(Statement):
     def gencode(self):
         headers = "" if not self.headers else \
                   "\n".join(["#include <%s>" % h for h in self.headers])
-        sign_list = self.pred + [self.ret, self.name,
-                                 wrap(", ".join([arg.gencode(True) for arg in self.args]))]
+        sign_list = self.template + self.pred + [self.ret, self.name,
+                                                 wrap(", ".join([arg.gencode(True) for arg in self.args]))]
         return headers + "\n" + " ".join(sign_list) + \
             "\n{\n%s\n}" % indent(self.children[0].gencode())
 

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -138,23 +138,11 @@ class ASTKernel(object):
                         # of the expression
                         vect.specialize(*vectorize)
 
-            # First we check if our kernel function is templated
-            templated = False
-            for q in kernel.pred:
-                if q == 'template <typename Derived>':
-                    templated = True
-
             # Ensure kernel is always marked static inline
-            # Remove any instances of static, inline and template <typename Derived>
-            # (so that we get the order right)
-            kernel.pred = [q for q in kernel.pred
-                           if q not in ['static', 'inline', 'template <typename Derived>']]
+            # Remove either or both of static and inline (so that we get the order right)
+            kernel.pred = [q for q in kernel.pred if q not in ['static', 'inline']]
             kernel.pred.insert(0, 'inline')
             kernel.pred.insert(0, 'static')
-
-            # If templated, mark appropriately
-            if templated:
-                kernel.pred.insert(0, 'template <typename Derived>')
 
             # Post processing of the AST ensures higher-quality code
             postprocess(kernel)

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -138,6 +138,24 @@ class ASTKernel(object):
                         # of the expression
                         vect.specialize(*vectorize)
 
+            # First we check if our kernel function is templated
+            templated = False
+            for q in kernel.pred:
+                if q == 'template <typename Derived>':
+                    templated = True
+
+            # Ensure kernel is always marked static inline
+            # Remove any instances of static, inline and template <typename Derived>
+            # (so that we get the order right)
+            kernel.pred = [q for q in kernel.pred
+                           if q not in ['static', 'inline', 'template <typename Derived>']]
+            kernel.pred.insert(0, 'inline')
+            kernel.pred.insert(0, 'static')
+
+            # If templated, mark appropriately
+            if templated:
+                kernel.pred.insert(0, 'template <typename Derived>')
+
             # Post processing of the AST ensures higher-quality code
             postprocess(kernel)
 

--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -138,12 +138,6 @@ class ASTKernel(object):
                         # of the expression
                         vect.specialize(*vectorize)
 
-            # Ensure kernel is always marked static inline
-            # Remove either or both of static and inline (so that we get the order right)
-            kernel.pred = [q for q in kernel.pred if q not in ['static', 'inline']]
-            kernel.pred.insert(0, 'inline')
-            kernel.pred.insert(0, 'static')
-
             # Post processing of the AST ensures higher-quality code
             postprocess(kernel)
 


### PR DESCRIPTION
This PR is made in anticipation of the SLATE merge coming soon. SLATE's tensor compiler produces template kernel functions of the form: `template <typename Derived> static inline ...` in order to populate the SLATE tensors.

The proposed change leaves the `static inline` check already present in `coffee/plan.py` (originally I removed them), and simply extends `FunDecl` in `base.py` to support an optional `template` parameter for creating template functions.
