### PR TITLE
Python 3 compatibility fixes

### DIFF
--- a/coffee/cse.py
+++ b/coffee/cse.py
@@ -32,6 +32,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import absolute_import, print_function, division
+from six import iterkeys, iteritems, itervalues
 from six.moves import zip
 
 import operator
@@ -99,7 +100,7 @@ class Temporary(object):
 
     @property
     def linear_reads(self):
-        return self.linear_reads_costs.keys() if self.linear_reads_costs else []
+        return list(iterkeys(self.linear_reads_costs)) if self.linear_reads_costs else []
 
     @property
     def loops(self):
@@ -205,11 +206,11 @@ class CSEUnpicker(object):
 
     @property
     def type(self):
-        return self.exprs.values()[0].type
+        return list(itervalues(self.exprs))[0].type
 
     @property
     def linear_dims(self):
-        return self.exprs.values()[0].linear_dims
+        return list(itervalues(self.exprs))[0].linear_dims
 
     def _push_temporaries(self, temporaries, trace, global_trace, ra, decls):
 
@@ -261,14 +262,14 @@ class CSEUnpicker(object):
         # Transform the AST (note: node replacement must happen in the order
         # in which the temporaries have been encountered)
         modified_temporaries = sorted(modified_temporaries.values(),
-                                      key=lambda t: global_trace.keys().index(t.urepr))
+                                      key=lambda t: list(iterkeys(global_trace)).index(t.urepr))
         for t in modified_temporaries:
             ast_replace(t.node, to_replace, copy=True)
         replaced = [t.urepr for t in to_replace.keys()]
 
         # Update the temporaries
         for t in modified_temporaries:
-            for r, c in t.linear_reads_costs.items():
+            for r, c in list(iteritems(t.linear_reads_costs)):
                 if r.urepr in replaced:
                     t.linear_reads_costs.pop(r)
                     r_linear_reads_costs = global_trace[r.urepr].linear_reads_costs
@@ -412,7 +413,7 @@ class CSEUnpicker(object):
                     else:
                         handle = [read]
                     linear_reads.extend(handle)
-                factors = {as_urepr(i): i for i in linear_reads}.values()
+                factors = list(itervalues({as_urepr(i): i for i in linear_reads}))
                 # Take into account the increased number of sums (due to fact)
                 hoist_region = set.union(*[lda[i] for i in factors])
                 niters = t.niters('out', hoist_region)

--- a/coffee/scheduler.py
+++ b/coffee/scheduler.py
@@ -836,11 +836,13 @@ class ZeroRemover(LoopScheduler):
             # Split the main expressions to maximize the impact of the rescheduling (this
             # helps if different summands have zero-valued blocks at different offsets)
             elf = ExpressionFissioner(cut=1, loops='none')
-            for stmt, expr_info in list(iteritems(self.exprs)):
+            new_exprs = {}
+            for stmt, expr_info in iteritems(self.exprs):
                 if expr_info.is_scalar:
-                    continue
-                self.exprs.pop(stmt)
-                self.exprs.update(elf.fission(stmt, expr_info))
+                    new_exprs[stmt] = expr_info
+                else:
+                    new_exprs.update(elf.fission(stmt, expr_info))
+            self.exprs = new_exprs
 
             # Apply the rescheduling
             nz_syms, nz_info = self._reschedule_itspace(root, candidates, decls)

--- a/coffee/scheduler.py
+++ b/coffee/scheduler.py
@@ -32,6 +32,7 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import absolute_import, print_function, division
+from six import iteritems
 from six.moves import range, zip
 
 from collections import OrderedDict, defaultdict
@@ -835,7 +836,7 @@ class ZeroRemover(LoopScheduler):
             # Split the main expressions to maximize the impact of the rescheduling (this
             # helps if different summands have zero-valued blocks at different offsets)
             elf = ExpressionFissioner(cut=1, loops='none')
-            for stmt, expr_info in self.exprs.items():
+            for stmt, expr_info in list(iteritems(self.exprs)):
                 if expr_info.is_scalar:
                     continue
                 self.exprs.pop(stmt)

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -431,8 +431,8 @@ def check_type(stmt, decls):
                   the name of a symbol) to Decl nodes
     """
     v = SymbolReferences()
-    lhs_symbol = v.visit(stmt.lvalue, parent=stmt, ret=v.default_retval()).keys()[0]
-    rhs_symbols = v.visit(stmt.rvalue, parent=stmt, ret=v.default_retval()).keys()
+    lhs_symbol, = iterkeys(v.visit(stmt.lvalue, parent=stmt, ret=v.default_retval()))
+    rhs_symbols = iterkeys(v.visit(stmt.rvalue, parent=stmt, ret=v.default_retval()))
 
     lhs_decl = decls[lhs_symbol]
     rhs_decls = [decls[s] for s in rhs_symbols if s in decls]


### PR DESCRIPTION
`.keys()`, `.items()`, `.values()` of `dict` return iterables rather than lists in Python 3.