### PR TITLE
Resolving SLATE conflicts in type checking

### DIFF
--- a/coffee/plan.py
+++ b/coffee/plan.py
@@ -93,7 +93,11 @@ class ASTKernel(object):
                 parent, nest = expr_info
                 if not nest:
                     continue
-                metaexpr = MetaExpr(check_type(stmt, info['decls']), parent, nest)
+                if kernel.template:
+                    typ = "double"
+                else:
+                    typ = check_type(stmt, info['decls'])
+                metaexpr = MetaExpr(typ, parent, nest)
                 nests[nest[0]].update({stmt: metaexpr})
             loop_opts = [CPULoopOptimizer(loop, header, exprs)
                          for (loop, header), exprs in nests.items()]
@@ -186,7 +190,11 @@ class ASTKernel(object):
                 parent, nest = expr_info
                 if not nest:
                     continue
-                metaexpr = MetaExpr(check_type(stmt, info['decls']), parent, nest)
+                if kernel.template:
+                    typ = "double"
+                else:
+                    typ = check_type(stmt, info['decls'])
+                metaexpr = MetaExpr(typ, parent, nest)
                 nests[nest[0]].update({stmt: metaexpr})
             loop_opts = [GPULoopOptimizer(loop, header, exprs)
                          for (loop, header), exprs in nests.items()]

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -431,7 +431,7 @@ def check_type(stmt, decls):
                   the name of a symbol) to Decl nodes
     """
     v = SymbolReferences()
-    lhs_symbol, = iterkeys(v.visit(stmt.lvalue, parent=stmt, ret=v.default_retval()))
+    lhs_symbol = list(iterkeys(v.visit(stmt.lvalue, parent=stmt, ret=v.default_retval())))[0]
     rhs_symbols = iterkeys(v.visit(stmt.rvalue, parent=stmt, ret=v.default_retval()))
 
     lhs_decl = decls[lhs_symbol]

--- a/coffee/utils.py
+++ b/coffee/utils.py
@@ -431,7 +431,7 @@ def check_type(stmt, decls):
                   the name of a symbol) to Decl nodes
     """
     v = SymbolReferences()
-    lhs_symbol = list(iterkeys(v.visit(stmt.lvalue, parent=stmt, ret=v.default_retval())))[0]
+    lhs_symbol, = iterkeys(v.visit(stmt.lvalue, parent=stmt, ret=v.default_retval()))
     rhs_symbols = iterkeys(v.visit(stmt.rvalue, parent=stmt, ret=v.default_retval()))
 
     lhs_decl = decls[lhs_symbol]


### PR DESCRIPTION
This is a minor PR that attempts to make COFFEE compatible with SLATE. The problem lies in `def check_type` in `coffee/utils.py`. The type of `lhs_decl` will always be `"Eigen::MatrixBase<Derived>"` in the SLATE case. Rather than hard-coding the type check for the eigen matrix, `kernel.template` is examined instead. This is an indirect way to address the SLATE case, as kernels will always be templated.