### PR TITLE
Complex: fix formatting of real literals

### DIFF
--- a/coffee/base.py
+++ b/coffee/base.py
@@ -271,9 +271,11 @@ class ArrayInit(Expr):
         elif isnan(v):
             return "NAN"
         elif abs(v.real - round(v.real, 1)) < eps and abs(v.imag - round(v.imag, 1)) < eps:
-            return f_int % v.real + ' + ' + f_int % v.imag + ' * I'
+            formatter = f_int
         else:
-            return f % v.real + ' + ' + f % v.imag + ' * I'
+            formatter = f
+        re, im, zero = map(lambda arg: formatter % arg, (v.real, v.imag, 0))
+        return re if im == zero else re + ' + ' + im + ' * I'
 
     def _tabulate_values(self, arr):
         if len(arr.shape) == 1:


### PR DESCRIPTION
Format real literals as real. Allows to run in real mode when a standard definition of `I` might not be satisfactory for compiler:

```
static const double  t3[1][3]  = {{0.33333333 + 0 * I, 0.33333333 + 0 * I, 0.33333333 + 0 * I}};
```

becomes

```
static const double  t3[1][3]  = {{0.33333333, 0.33333333, 0.33333333}};
```
